### PR TITLE
Deploy to Fly.io via GitHub Actions

### DIFF
--- a/.github/deploy-fly/fly.template.toml
+++ b/.github/deploy-fly/fly.template.toml
@@ -1,0 +1,31 @@
+app = "__FLY_APP__"
+kill_signal = "SIGINT"
+kill_timeout = "5s"
+primary_region = "__FLY_PRIMARY_REGION__"
+
+[build]
+dockerfile = "Dockerfile"
+
+[env]
+LINECORP_PLATFORM_LOGIN_CHANNEL_CALLBACKURL = "__LINE_LOGIN_CALLBACK_URL__"
+NODE_ENV = "production"
+
+[experimental]
+auto_rollback = true
+
+  [experimental.attached]
+  secrets = { }
+
+[http_service]
+auto_start_machines = true
+auto_stop_machines = true
+force_https = true
+internal_port = 3_000
+min_machines_running = 0
+processes = [ "app" ]
+
+[processes]
+app = "node /app/index.js"
+
+[[vm]]
+size = "shared-cpu-1x"

--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master

--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -1,0 +1,78 @@
+name: Deploy to Fly.io
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-fly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Validate required configuration
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_APP: ${{ vars.FLY_APP }}
+          FLY_PRIMARY_REGION: ${{ vars.FLY_PRIMARY_REGION }}
+          LINE_LOGIN_CALLBACK_URL: ${{ vars.LINE_LOGIN_CALLBACK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FLY_API_TOKEN:-}" ]; then
+            echo "Missing required secret: FLY_API_TOKEN" >&2
+            exit 1
+          fi
+
+          for key in FLY_APP FLY_PRIMARY_REGION LINE_LOGIN_CALLBACK_URL; do
+            if [ -z "${!key:-}" ]; then
+              echo "Missing required variable: ${key}" >&2
+              exit 1
+            fi
+          done
+
+      - name: Render fly.toml from template
+        env:
+          FLY_APP: ${{ vars.FLY_APP }}
+          FLY_PRIMARY_REGION: ${{ vars.FLY_PRIMARY_REGION }}
+          LINE_LOGIN_CALLBACK_URL: ${{ vars.LINE_LOGIN_CALLBACK_URL }}
+        run: |
+          set -euo pipefail
+
+          cp .github/deploy-fly/fly.template.toml .fly.generated.toml
+
+          sed -i "s|__FLY_APP__|${FLY_APP}|g" .fly.generated.toml
+          sed -i "s|__FLY_PRIMARY_REGION__|${FLY_PRIMARY_REGION}|g" .fly.generated.toml
+          sed -i "s|__LINE_LOGIN_CALLBACK_URL__|${LINE_LOGIN_CALLBACK_URL}|g" .fly.generated.toml
+
+      - name: Deploy
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_APP: ${{ vars.FLY_APP }}
+          NO_COLOR: "1"
+        run: |
+          set -euo pipefail
+          flyctl deploy \
+            --local-only \
+            --debug \
+            --verbose \
+            --config .fly.generated.toml \
+            --app "$FLY_APP"
+
+      - name: Clean up generated config
+        if: ${{ always() }}
+        run: rm -f .fly.generated.toml

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@ npm-debug.log
 *.dev
 .eslintrc
 .DS_Store
-Dockerfile
 docker-compose.yml
 fly.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-bookworm-slim
+WORKDIR /app
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends python3 make g++ \
+	&& rm -rf /var/lib/apt/lists/*
+COPY package.json package-lock.json /app/
+RUN npm install --omit=dev
+COPY . /app
+EXPOSE 3000

--- a/docs/deploy-fly.md
+++ b/docs/deploy-fly.md
@@ -1,0 +1,92 @@
+# Fly.io deploy guide (GitHub Actions)
+
+このドキュメントは、GitHub Actions から Fly.io へデプロイするための手順をまとめたものです。
+機密情報はリポジトリに保存しません。`fly.toml` は CI 実行時にテンプレートから生成します。
+
+ビルドは `Dockerfile` を使います。
+
+## Actions で設定不要なパラメータ
+
+以下は Fly.io 側で管理し、GitHub Actions からは設定しません。
+
+- `DATABASE_URL`
+- `LINECORP_PLATFORM_LOGIN_CHANNEL_ID`
+- `LINECORP_PLATFORM_LOGIN_CHANNEL_SECRET`
+- `LINECORP_PLATFORM_MESSAGING_CHANNEL_ACCESSTOKEN`
+- `LINECORP_PLATFORM_MESSAGING_CHANNEL_SECRET`
+- `MQTT_URI`
+- `MQTT_USER`
+- `MQTT_PASS`
+- `MQTT_TOPIC`
+
+## fly.toml で変数化する最小項目
+
+`fly.toml` テンプレートでは次の 3 項目だけを置換対象にします。
+
+テンプレートファイルの配置先:
+
+- `.github/deploy-fly/fly.template.toml`
+
+- `app`
+- `primary_region`
+- `LINECORP_PLATFORM_LOGIN_CHANNEL_CALLBACKURL`
+
+## 追加で指定を推奨する項目
+
+- `NODE_ENV`
+  - 本番挙動を安定化するため
+- `internal_port`
+  - アプリと Fly 設定の不一致を防ぐため
+- `processes.app`
+  - `node /app/index.js` のように実行コマンドを明示して起動失敗を避けるため
+
+## GitHub Secrets（Actions 実行用）
+
+設定する Secrets は次の 1 つだけです。
+
+- `FLY_API_TOKEN`
+
+## GitHub Variables（Actions 実行用）
+
+以下の Variables を設定します。
+
+- `FLY_APP`
+- `FLY_PRIMARY_REGION`
+- `LINE_LOGIN_CALLBACK_URL`
+
+## Secret のサンプル値（ダミー）
+
+実運用の値は絶対に貼り付けないでください。以下はダミーです。
+
+- `FLY_API_TOKEN`
+  - `flyv1_dummy_token_replace_this_value`
+- `FLY_APP` (Variable)
+  - `example-fly-app`
+- `FLY_PRIMARY_REGION` (Variable)
+  - `nrt`
+- `LINE_LOGIN_CALLBACK_URL` (Variable)
+  - `https://example-fly-app.example.com/callback`
+
+## fly auth login の扱い
+
+GitHub Actions では対話ログインを行いません。
+`FLY_API_TOKEN` を設定して認証します。
+
+## デプロイ手順
+
+1. Secrets を登録する
+2. Variables を登録する
+3. `.github/workflows/deploy-fly.yml` を `master` へマージする
+4. `master` への push か `workflow_dispatch` でデプロイを実行する
+5. Actions ログで deploy 成功を確認する
+
+## 検証項目
+
+- ログにトークンや URL の実値が出ていない
+- Fly アプリが正常起動している
+- Login callback URL が期待どおり反映されている
+
+## トラブル時
+
+- `Missing required secret` または `Missing required variable` が出たら、Secrets / Variables を確認する
+- 誤って機密を出力した場合は、該当 Secret を即時ローテーションする


### PR DESCRIPTION
GitHub ActionsでFly.ioへ自動デプロイするワークフローを追加・整備しました。

- Dockerfileベースのビルドに統一
- .gitignore修正でCIビルド安定化
- Node20廃止警告の最小対応（actions/checkout@v5）

npm deprecated警告は現状維持です。