### PR TITLE
ci: Ignore historical README gitleaks findings

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,2 @@
+78f7b87e65fef0b4012c4a7952dc9e138e40410c:README.md:generic-api-key:79
+78f7b87e65fef0b4012c4a7952dc9e138e40410c:README.md:generic-api-key:82


### PR DESCRIPTION
## 概要
- gitleaks が検出していた README の過去コミット上の 2 件を .gitleaksignore に追加
- README 全体やコミット全体ではなく、Actions run のログに出ていた fingerprint のみに対象を限定
- PR #42 で現行 README から設定例は削除済みだが、全履歴スキャンでは過去コミットが検出対象になるため追加対応

## 確認
- gitleaks 8.24.3: no leaks found
- gitleaks 8.30.1: no leaks found
- commit 時の pre-commit gitleaks hook: passed