### PR TITLE
Improve observability logging

### DIFF
--- a/app/create-app.js
+++ b/app/create-app.js
@@ -12,23 +12,25 @@ const { createWebhookRoutes } = require('../routes/webhook-routes');
 const { createPageRoutes } = require('../routes/page-routes');
 const { createApiRoutes } = require('../routes/api-routes');
 
+const createSafeLogId = (value) => logger.createLogCorrelationId(value);
+
 const createHelpers = ({
   db,
   msgbot,
 }) => {
   const isLoggedIn = async (extUserId) => {
     if(!extUserId) {
-      logger.logInfo('isLoggedIn', { extUserId });
+      logger.logInfo('isLoggedIn', { extUserKey: createSafeLogId(extUserId) });
       return false;
     }
     const existUser = await db.getUserByExtUserId(extUserId);
     if(!existUser) {
-      logger.logInfo('isLoggedIn:userNotFound', { extUserId });
+      logger.logInfo('isLoggedIn:userNotFound', { extUserKey: createSafeLogId(extUserId) });
       return false;
     }
     logger.logInfo('isLoggedIn:userFound', {
-      extUserId,
-      existingExtUserId: existUser.ext_user_id,
+      extUserKey: createSafeLogId(extUserId),
+      existingExtUserKey: createSafeLogId(existUser.ext_user_id),
     });
     return (extUserId === existUser.ext_user_id);
   };

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -307,15 +307,32 @@ curl -i \
 
 期待値:
 
-- 400
-- JSON に `error.code: INVALID_CHARSETS_PAYLOAD`
+- 200
+- `mail_webhook.invalid_charsets_ignored` の warning ログ
+- 可能な範囲で UTF-8 として本文を復元し、LINE 通知を継続する
 
 ### ログの検証
 
-標準出力の debug ログで次を確認する。
+標準出力・標準エラーの JSON ログで次を確認する。`info` は標準出力、`warn` / `error` は標準エラーへ出力される。
 
 - `request.started`
 - `request.completed`
+- `mail_webhook.received`
+- `mail_webhook.signature.verified`
+- `mail_webhook.recipient.resolved`
+- `mail_webhook.body.selected`
+- `mail_webhook.message.prepared`
+- `line.push.started`
+- LINE push 成功時は `line.push.succeeded`
 - LINE push の一時障害時は `line.push.retry`
+- LINE push の最終失敗時は `line.push.failed`
 - MQTT publish の一時障害時は `mqtt.publish.retry`
 - 失敗時は `request.failed`
+
+#### ログを使った切り分け
+
+- メールが届いたか確認する: `requestId` で `request.started`、`mail_webhook.received`、`mail_webhook.signature.verified` の順に出ているかを見る
+- 宛先解決を確認する: `mail_webhook.recipient.resolved` が出ているかを見る。宛先や LINE ID の全文は出さず、短い相関キーだけを出す
+- LINE 通知を確認する: `line.push.started` の後に `line.push.succeeded` または `line.push.failed` が出ているかを見る
+- 文字化けを確認する: `mail_webhook.part.transfer_decoded`、`mail_webhook.part.charset_converted`、`mail_webhook.part.charset_conversion_failed` を見る
+- メール本文、件名、from、LINE メッセージ本文、LINE ID の全文はログへ出さない

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -333,6 +333,6 @@ curl -i \
 
 - メールが届いたか確認する: `requestId` で `request.started`、`mail_webhook.received`、`mail_webhook.signature.verified` の順に出ているかを見る
 - 宛先解決を確認する: `mail_webhook.recipient.resolved` が出ているかを見る。宛先や LINE ID の全文は出さず、短い相関キーだけを出す
-- LINE 通知を確認する: `line.push.started` の後に `line.push.succeeded` または `line.push.failed` が出ているかを見る
+- LINE 通知を確認する: `line.push.started` の後に `line.push.succeeded` または `line.push.failed` が出ているかを見る。最終失敗時は `request.failed` の `code` と `httpStatus` も見る
 - 文字化けを確認する: `mail_webhook.part.transfer_decoded`、`mail_webhook.part.charset_converted`、`mail_webhook.part.charset_conversion_failed` を見る
 - メール本文、件名、from、LINE メッセージ本文、LINE ID の全文はログへ出さない

--- a/docs/deploy-fly.md
+++ b/docs/deploy-fly.md
@@ -86,6 +86,29 @@ GitHub Actions では対話ログインを行いません。
 - Fly アプリが正常起動している
 - Login callback URL が期待どおり反映されている
 
+## Fly Grafana での運用確認
+
+Fly.io の managed Grafana では、Fly が自動で収集する HTTP レスポンス系の metrics を確認できます。
+アプリ固有の切り分けは、標準出力・標準エラーに出る JSON ログと合わせて確認します。
+
+Grafana を開く例:
+
+```bash
+fly dashboard metrics -a <fly-app-name> --grafana
+```
+
+HTTP 5xx を見る例:
+
+```promql
+sum(increase(fly_app_http_responses_count{app="<fly-app-name>",status=~"5.."}[10m]))
+```
+
+環境や見たい入口によっては、`fly_edge_http_responses_count` も確認します。`fly_app_http_responses_count` はアプリ側で返したレスポンス、`fly_edge_http_responses_count` は Fly edge 側で見えたレスポンスの確認に使います。
+
+メール webhook の LINE push 最終失敗は、アプリでは `LINE_PUSH_FAILED` として HTTP 502 を返します。Fly Grafana では HTTP 5xx の増加を見て、該当時間帯の JSON ログで `line.push.failed` と `request.failed` を確認します。
+
+文字コード変換失敗は `mail_webhook.part.charset_conversion_failed` の warning ログで確認します。この場合は可能な範囲で UTF-8 として本文復元を継続するため、HTTP 200 になることがあります。Fly の HTTP 5xx metrics だけでは検知できないため、文字化け調査では JSON ログを確認します。
+
 ## トラブル時
 
 - `Missing required secret` または `Missing required variable` が出たら、Secrets / Variables を確認する

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -192,9 +192,11 @@ sequenceDiagram
 - /mail-webhook は処理完了後に 200 を返し、既知エラーは共通エラーフォーマットで返す
 - /mail-webhook は添付をメモリ保持しないが、text または html 本文は UTF-8 変換のために保持する
 - transfer-encoding / charset 変換で失敗した場合は warning ログを残し、本文復旧のため UTF-8 デコードへフォールバックする
+- charsets の JSON が不正な場合は warning ログを残し、可能な範囲で UTF-8 として本文復元と LINE 通知を継続する
 - LINE 送信メッセージは 1 本の text message に集約される
 - LINE 送信メッセージが 5000 文字を超える場合は、`（省略）` を付けて切り詰める
 - MQTT payload は data キーを持つ単純な JSON
 - セッション secret は LINE Login の channel secret を流用している
-- API/webhook には `x-request-id` を付与し、構造化ログで `request.started` と `request.completed` を出す
+- API/webhook には `x-request-id` を付与し、構造化ログで `request.started`、`request.completed`、mail webhook の処理段階、LINE push の開始/成功/失敗を出す
+- ログにはメール本文、件名、from、LINE メッセージ本文、LINE ID の全文を出さない
 - LINE push と MQTT publish は一時障害時に最小限の再試行を行う

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,18 +1,64 @@
-const { randomUUID } = require('crypto');
-const debug = require('debug')('index');
+const {
+  createHash,
+  randomUUID,
+} = require('crypto');
 
 const createRequestId = () => randomUUID();
 
-const createLogEntry = (level, event, details = {}) => JSON.stringify({
-  level,
-  event,
-  timestamp: new Date().toISOString(),
-  ...details,
-});
+const reservedLogFields = new Set(['level', 'event', 'timestamp']);
 
-const logInfo = (event, details) => debug(createLogEntry('info', event, details));
-const logWarn = (event, details) => debug(createLogEntry('warn', event, details));
-const logError = (event, details) => debug(createLogEntry('error', event, details));
+const sanitizeLogDetails = (details = {}) => {
+  if (!details || typeof details !== 'object') {
+    return { detailValue: details };
+  }
+
+  return Object.keys(details).reduce((acc, key) => {
+    if (reservedLogFields.has(key)) {
+      acc[`detail_${key}`] = details[key];
+      return acc;
+    }
+
+    acc[key] = details[key];
+    return acc;
+  }, {});
+};
+
+const createLogEntry = (level, event, details = {}) => {
+  const entry = {
+    ...sanitizeLogDetails(details),
+    level,
+    event,
+    timestamp: new Date().toISOString(),
+  };
+
+  try {
+    return JSON.stringify(entry);
+  } catch (error) {
+    return JSON.stringify({
+      level,
+      event: 'logger.stringify_failed',
+      timestamp: new Date().toISOString(),
+      originalEvent: event,
+      message: error && error.message,
+    });
+  }
+};
+
+const writeLogEntry = (stream, level, event, details) => {
+  stream.write(`${createLogEntry(level, event, details)}\n`);
+};
+
+const logInfo = (event, details) => writeLogEntry(process.stdout, 'info', event, details);
+const logWarn = (event, details) => writeLogEntry(process.stderr, 'warn', event, details);
+const logError = (event, details) => writeLogEntry(process.stderr, 'error', event, details);
+
+const createLogCorrelationId = (value) => {
+  if (!value) {
+    return undefined;
+  }
+
+  return createHash('sha256').update(String(value)).digest('hex').slice(0, 12);
+};
 
 const getRequestCompletionLogger = (statusCode) => {
   if (statusCode >= 500) {
@@ -47,6 +93,7 @@ const createRequestLogger = () => (req, res, next) => {
 
 module.exports = {
   createLogEntry,
+  createLogCorrelationId,
   createRequestId,
   createRequestLogger,
   getRequestCompletionLogger,

--- a/lib/mail-webhook.js
+++ b/lib/mail-webhook.js
@@ -8,6 +8,7 @@ const {
 const {
   isUtf8Charset,
   decodeUtf8Buffer,
+  convertUtf8,
   truncateLineTextMessage,
 } = require('./mail-text');
 const { AppError } = require('./errors');
@@ -20,6 +21,17 @@ const lineTextMessageMaxChars = 5000;
 const lineTextMessageTruncationMarker = '\r\n（省略）';
 const trackedMultipartFieldNames = new Set(['to', 'from', 'subject', 'charsets', 'text', 'html']);
 const utf8MultipartFieldNames = new Set(['to', 'from', 'subject', 'charsets']);
+
+const createSafeLogId = (logger, value) => {
+  if (!value) {
+    return undefined;
+  }
+  if (logger && typeof logger.createLogCorrelationId === 'function') {
+    return logger.createLogCorrelationId(value);
+  }
+
+  return undefined;
+};
 
 const getMultipartBoundary = (contentType) => {
   const matched = contentType.match(/boundary=(?:"([^"]+)"|([^;]+))/i);
@@ -134,6 +146,13 @@ const decodeAndConvertMailPart = ({
   if (transferEncoding) {
     try {
       decodedBuffer = decodeTransferEncodedBuffer(part.data, transferEncoding);
+      logger.logInfo('mail_webhook.part.transfer_decoded', {
+        requestId,
+        partName,
+        transferEncoding,
+        bytesBefore: part.data.length,
+        bytesAfter: decodedBuffer.length,
+      });
     } catch (error) {
       logger.logWarn('mail_webhook.transfer_decode_failed', {
         requestId,
@@ -145,11 +164,24 @@ const decodeAndConvertMailPart = ({
     }
   }
 
-  if (charsetHint && !isUtf8Charset(charsetHint)) {
-    logger.logInfo('mail_webhook.charset_hint_ignored', {
+  try {
+    const convertedText = isUtf8Charset(charsetHint)
+      ? decodeUtf8Buffer(decodedBuffer)
+      : convertUtf8(decodedBuffer, charsetHint);
+    logger.logInfo('mail_webhook.part.charset_converted', {
       requestId,
       partName,
       charsetHint,
+      bytes: decodedBuffer.length,
+      chars: Array.from(convertedText).length,
+    });
+    return convertedText;
+  } catch (error) {
+    logger.logWarn('mail_webhook.part.charset_conversion_failed', {
+      requestId,
+      partName,
+      charsetHint,
+      message: error && error.message,
     });
   }
 
@@ -207,9 +239,17 @@ const createMailWebhookHandler = ({
       formParts,
       rawBody,
     } = await streamMultipartForm(req, maxBytes);
+    logger.logInfo('mail_webhook.received', {
+      requestId: req.requestId,
+      rawBodyBytes: rawBody.length,
+      fields: Object.keys(formParts).sort(),
+    });
     verifyInboundParseWebhookSignature({
       headers: req.headers,
       rawBody,
+    });
+    logger.logInfo('mail_webhook.signature.verified', {
+      requestId: req.requestId,
     });
     const form = Object.keys(formParts).reduce((acc, key) => ({
       ...acc,
@@ -231,13 +271,20 @@ const createMailWebhookHandler = ({
       throw new AppError('INVALID_TO_ADDRESS', 'Invalid To address.', 400);
     }
     const recipient = await db.getEnabledRecipientByEmail(`${mailTo[0].local}`);
+    const recipientAddressKey = createSafeLogId(logger, mailTo[0].local);
     if (!recipient) {
       logger.logWarn('mail_webhook.unknown_recipient', {
         requestId: req.requestId,
-        localPart: mailTo[0].local,
+        recipientAddressKey,
       });
       throw new AppError('UNKNOWN_RECIPIENT', 'Unknown recipient.', 404);
     }
+    const lineRecipientKey = createSafeLogId(logger, recipient.line_recipient_id);
+    logger.logInfo('mail_webhook.recipient.resolved', {
+      requestId: req.requestId,
+      recipientAddressKey,
+      lineRecipientKey,
+    });
 
     const mailContent = {
       'from': form.from || '',
@@ -245,6 +292,10 @@ const createMailWebhookHandler = ({
       'body': ''
     };
     if (formParts.text && formParts.text.data) {
+      logger.logInfo('mail_webhook.body.selected', {
+        requestId: req.requestId,
+        partName: 'text',
+      });
       mailContent.body = decodeAndConvertMailPart({
         part: formParts.text,
         charsetHint: mailCharsets.text,
@@ -254,6 +305,10 @@ const createMailWebhookHandler = ({
       });
     }
     else if (formParts.html && formParts.html.data) {
+      logger.logInfo('mail_webhook.body.selected', {
+        requestId: req.requestId,
+        partName: 'html',
+      });
       const htmlBody = decodeAndConvertMailPart({
         part: formParts.html,
         charsetHint: mailCharsets.html,
@@ -263,9 +318,22 @@ const createMailWebhookHandler = ({
       });
       mailContent.body = htmlToText.convert(htmlBody);
     }
-    const msgBody = truncateLineTextMessage(`From: ${mailContent.from}\r\nSubject: ${mailContent.subject}\r\n\r\n${mailContent.body}`, {
+    const lineMessageText = `From: ${mailContent.from}\r\nSubject: ${mailContent.subject}\r\n\r\n${mailContent.body}`;
+    const charsBefore = Array.from(lineMessageText).length;
+    const msgBody = truncateLineTextMessage(lineMessageText, {
       maxChars: lineTextMessageMaxChars,
       marker: lineTextMessageTruncationMarker,
+    });
+    const charsAfter = Array.from(msgBody).length;
+    logger.logInfo('mail_webhook.message.prepared', {
+      requestId: req.requestId,
+      charsBefore,
+      charsAfter,
+      truncated: charsAfter < charsBefore,
+    });
+    logger.logInfo('line.push.started', {
+      requestId: req.requestId,
+      lineRecipientKey,
     });
     await retryAsync({
       operation: () => msgbot.pushMessage({
@@ -287,17 +355,27 @@ const createMailWebhookHandler = ({
       const lineRequestId = err && err.headers && typeof err.headers.get === 'function'
         ? err.headers.get('x-line-request-id')
         : undefined;
+      logger.logError('line.push.failed', {
+        requestId: req.requestId,
+        lineRecipientKey,
+        statusCode: err && (err.statusCode || err.status),
+        lineRequestId,
+        message: err && err.message,
+      });
       throw new AppError('LINE_PUSH_FAILED', 'Failed to push message to LINE.', 502, {
         statusCode: err && (err.statusCode || err.status),
         lineRequestId,
-        body: err && err.body,
       });
     });
     logger.logInfo('line.push.succeeded', {
       requestId: req.requestId,
-      recipientId: recipient.line_recipient_id,
+      lineRecipientKey,
     });
     if (mqttPublish !== null) {
+      logger.logInfo('mqtt.publish.started', {
+        requestId: req.requestId,
+        topic: mqttPublish.topic,
+      });
       retryAsync({
         operation: () => mqttPublish.publish(mailContent.subject),
         retries: 2,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "node test/decode-transfer-encoding.test.js && node test/mail-text.test.js && node test/e2e-mail-samples.test.js && node test/csrf-protection.test.js && node test/session-security.test.js && node test/address-ownership.test.js && node test/inbound-parse-webhook-signature.test.js && node test/errors.test.js && node test/app-wiring.test.js && node test/codeql-fixes.test.js && node test/mail-webhook-rate-limit.test.js"
+    "test": "node test/logger.test.js && node test/decode-transfer-encoding.test.js && node test/mail-text.test.js && node test/e2e-mail-samples.test.js && node test/csrf-protection.test.js && node test/session-security.test.js && node test/address-ownership.test.js && node test/inbound-parse-webhook-signature.test.js && node test/errors.test.js && node test/app-wiring.test.js && node test/codeql-fixes.test.js && node test/mail-webhook-rate-limit.test.js && node test/mail-webhook-observability.test.js"
   },
   "engines": {
     "node": ">=20 <25"

--- a/routes/page-routes.js
+++ b/routes/page-routes.js
@@ -73,6 +73,11 @@ const createPageRoutes = ({
   const router = express.Router();
   const indexTemplate = path.join(rootDir, 'pages/index');
   const loginTemplate = path.join(rootDir, 'pages/login');
+  const createSafeLogId = (value) => (
+    logger && typeof logger.createLogCorrelationId === 'function'
+      ? logger.createLogCorrelationId(value)
+      : undefined
+  );
   const authRateLimiter = rateLimit(createRateLimitOptions({
     options: authRateLimit,
     defaults: defaultRateLimits.auth,
@@ -82,7 +87,10 @@ const createPageRoutes = ({
 
   router.get('/', async (req, res, next) => {
     const extUserId = req.session.userId;
-    logger.logInfo('page.index.render', { requestId: req.requestId, extUserId });
+    logger.logInfo('page.index.render', {
+      requestId: req.requestId,
+      extUserKey: createSafeLogId(extUserId),
+    });
     if (! await helpers.isLoggedIn(extUserId)) {
       res.redirect(`${req.baseUrl}/login`);
       return;
@@ -148,8 +156,8 @@ const createPageRoutes = ({
       delete req.session.line_login_nonce;
       logger.logInfo('auth.callback.succeeded', {
         requestId: req.requestId,
-        lineUserId,
-        userId,
+        lineUserKey: createSafeLogId(lineUserId),
+        userKey: createSafeLogId(userId),
       });
       return res.redirect(`${req.baseUrl}/`);
     } catch (error) {

--- a/routes/webhook-routes.js
+++ b/routes/webhook-routes.js
@@ -23,6 +23,11 @@ const createWebhookRoutes = ({
   logger,
 }) => {
   const router = express.Router();
+  const createSafeLogId = (value) => (
+    logger && typeof logger.createLogCorrelationId === 'function'
+      ? logger.createLogCorrelationId(value)
+      : undefined
+  );
 
   router.post('/msg-webhook', lineWebhookMiddleware, async (req, res, next) => {
     try {
@@ -33,7 +38,7 @@ const createWebhookRoutes = ({
         const lineGroupSummary = await msgbot.getGroupSummary(lineGroupId);
         logger.logInfo('line.group_join.recipient_sync', {
           requestId: req.requestId,
-          lineGroupId,
+          lineGroupKey: createSafeLogId(lineGroupId),
         });
         await db.addRecipient(lineGroupId, 1, lineGroupSummary.groupName.substring(0, 63));
       }

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,0 +1,90 @@
+const assert = require('assert');
+const {
+  createLogCorrelationId,
+  createLogEntry,
+  logError,
+  logInfo,
+  logWarn,
+} = require('../lib/logger');
+
+const captureStream = (stream) => {
+  const originalWrite = stream.write;
+  const chunks = [];
+
+  stream.write = (chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  };
+
+  return {
+    chunks,
+    restore: () => {
+      stream.write = originalWrite;
+    },
+  };
+};
+
+const run = () => {
+  {
+    const entry = JSON.parse(createLogEntry('info', 'test.event', {
+      event: 'override',
+      level: 'override',
+      timestamp: 'override',
+      requestId: 'request-id',
+      value: 1,
+    }));
+
+    assert.strictEqual(entry.level, 'info');
+    assert.strictEqual(entry.event, 'test.event');
+    assert.notStrictEqual(entry.timestamp, 'override');
+    assert.strictEqual(entry.detail_event, 'override');
+    assert.strictEqual(entry.detail_level, 'override');
+    assert.strictEqual(entry.detail_timestamp, 'override');
+    assert.strictEqual(entry.requestId, 'request-id');
+    assert.strictEqual(entry.value, 1);
+  }
+
+  {
+    const details = {};
+    details.self = details;
+    const entry = JSON.parse(createLogEntry('info', 'circular.event', details));
+
+    assert.strictEqual(entry.level, 'info');
+    assert.strictEqual(entry.event, 'logger.stringify_failed');
+    assert.strictEqual(entry.originalEvent, 'circular.event');
+    assert.match(entry.message, /circular/i);
+  }
+
+  {
+    const stdout = captureStream(process.stdout);
+    const stderr = captureStream(process.stderr);
+    try {
+      logInfo('info.event', { requestId: 'info-request' });
+      logWarn('warn.event', { requestId: 'warn-request' });
+      logError('error.event', { requestId: 'error-request' });
+    } finally {
+      stdout.restore();
+      stderr.restore();
+    }
+
+    assert.strictEqual(stdout.chunks.length, 1);
+    assert.strictEqual(stderr.chunks.length, 2);
+    assert.strictEqual(JSON.parse(stdout.chunks[0]).event, 'info.event');
+    assert.strictEqual(JSON.parse(stderr.chunks[0]).event, 'warn.event');
+    assert.strictEqual(JSON.parse(stderr.chunks[1]).event, 'error.event');
+  }
+
+  {
+    const first = createLogCorrelationId('U1234567890abcdef');
+    const second = createLogCorrelationId('U1234567890abcdef');
+
+    assert.strictEqual(first, second);
+    assert.strictEqual(first.length, 12);
+    assert.notStrictEqual(first, 'U1234567890abcdef');
+    assert.strictEqual(createLogCorrelationId(''), undefined);
+  }
+
+  console.log('logger tests passed');
+};
+
+run();

--- a/test/mail-webhook-observability.test.js
+++ b/test/mail-webhook-observability.test.js
@@ -1,0 +1,224 @@
+const assert = require('assert');
+const express = require('express');
+const { Iconv } = require('iconv');
+const request = require('supertest');
+const {
+  createMailWebhookHandler,
+  decodeAndConvertMailPart,
+} = require('../lib/mail-webhook');
+const { createErrorMiddleware } = require('../lib/errors');
+const {
+  createLogCorrelationId,
+} = require('../lib/logger');
+
+const createCaptureLogger = () => {
+  const entries = [];
+  const capture = (level) => (event, details = {}) => {
+    entries.push({
+      level,
+      event,
+      ...details,
+    });
+  };
+
+  return {
+    entries,
+    createLogCorrelationId,
+    logError: capture('error'),
+    logInfo: capture('info'),
+    logWarn: capture('warn'),
+  };
+};
+
+const createWebhookTestApp = ({
+  logger,
+  pushMessage = async () => ({}),
+  verifyInboundParseWebhookSignature = () => {},
+} = {}) => {
+  const app = express();
+  const resolvedLogger = logger || createCaptureLogger();
+
+  app.use((req, res, next) => {
+    req.requestId = 'test-request-id';
+    next();
+  });
+  app.post('/mail-webhook', createMailWebhookHandler({
+    db: {
+      getEnabledRecipientByEmail: async () => ({
+        line_recipient_id: 'U1234567890abcdef',
+      }),
+    },
+    msgbot: {
+      pushMessage,
+    },
+    mqttPublish: null,
+    logger: resolvedLogger,
+    verifyInboundParseWebhookSignature,
+  }));
+  app.use(createErrorMiddleware());
+
+  return {
+    app,
+    logger: resolvedLogger,
+  };
+};
+
+const postMailWebhook = (app, fields = {}) => {
+  const req = request(app)
+    .post('/mail-webhook')
+    .field('to', fields.to || 'notify@example.test')
+    .field('from', fields.from || 'sender-secret@example.test')
+    .field('subject', fields.subject || 'private subject')
+    .field('text', fields.text || 'private body');
+
+  if (Object.prototype.hasOwnProperty.call(fields, 'charsets')) {
+    req.field('charsets', fields.charsets);
+  }
+
+  return req;
+};
+
+const getEvents = (logger) => logger.entries.map(entry => entry.event);
+
+const assertNoSensitiveLogContent = (logger) => {
+  const serialized = JSON.stringify(logger.entries);
+
+  assert.doesNotMatch(serialized, /sender-secret@example\.test/);
+  assert.doesNotMatch(serialized, /private subject/);
+  assert.doesNotMatch(serialized, /private body/);
+  assert.doesNotMatch(serialized, /U1234567890abcdef/);
+  assert.doesNotMatch(serialized, /notify/);
+};
+
+const run = async () => {
+  {
+    const logger = createCaptureLogger();
+    const source = '日本語テスト123';
+    const encoder = new Iconv('UTF-8', 'SHIFT_JIS//TRANSLIT//IGNORE');
+    const sjisBuffer = encoder.convert(Buffer.from(source, 'utf8'));
+    const result = decodeAndConvertMailPart({
+      part: {
+        headers: {
+          'content-transfer-encoding': [''],
+        },
+        data: sjisBuffer,
+      },
+      charsetHint: 'windows-31j',
+      partName: 'text',
+      requestId: 'test-request-id',
+      logger,
+    });
+
+    assert.strictEqual(result, source);
+    assert.ok(getEvents(logger).includes('mail_webhook.part.charset_converted'));
+  }
+
+  {
+    const logger = createCaptureLogger();
+    const source = 'こんにちは世界';
+    const encoder = new Iconv('UTF-8', 'ISO-2022-JP//TRANSLIT//IGNORE');
+    const isoBuffer = encoder.convert(Buffer.from(source, 'utf8'));
+    const result = decodeAndConvertMailPart({
+      part: {
+        headers: {
+          'content-transfer-encoding': ['base64'],
+        },
+        data: Buffer.from(isoBuffer.toString('base64'), 'ascii'),
+      },
+      charsetHint: 'iso-2022-jp',
+      partName: 'text',
+      requestId: 'test-request-id',
+      logger,
+    });
+
+    assert.strictEqual(result, source);
+    assert.ok(getEvents(logger).includes('mail_webhook.part.transfer_decoded'));
+    assert.ok(getEvents(logger).includes('mail_webhook.part.charset_converted'));
+  }
+
+  {
+    const logger = createCaptureLogger();
+    const result = decodeAndConvertMailPart({
+      part: {
+        headers: {
+          'content-transfer-encoding': [''],
+        },
+        data: Buffer.from('fallback body', 'utf8'),
+      },
+      charsetHint: 'x-unsupported-charset',
+      partName: 'text',
+      requestId: 'test-request-id',
+      logger,
+    });
+
+    assert.strictEqual(result, 'fallback body');
+    assert.ok(getEvents(logger).includes('mail_webhook.part.charset_conversion_failed'));
+  }
+
+  {
+    let pushedText = '';
+    const logger = createCaptureLogger();
+    const { app } = createWebhookTestApp({
+      logger,
+      pushMessage: async ({ messages }) => {
+        pushedText = messages[0].text;
+      },
+    });
+
+    const res = await postMailWebhook(app, {
+      charsets: '{invalid-json}',
+    });
+
+    assert.strictEqual(res.status, 200);
+    assert.match(pushedText, /private body/);
+    assert.ok(getEvents(logger).includes('mail_webhook.invalid_charsets_ignored'));
+    assert.ok(getEvents(logger).includes('line.push.succeeded'));
+    assertNoSensitiveLogContent(logger);
+  }
+
+  {
+    const logger = createCaptureLogger();
+    const { app } = createWebhookTestApp({ logger });
+    const res = await postMailWebhook(app);
+    const events = getEvents(logger);
+    const resolvedLog = logger.entries.find(entry => entry.event === 'mail_webhook.recipient.resolved');
+
+    assert.strictEqual(res.status, 200);
+    assert.ok(events.includes('mail_webhook.received'));
+    assert.ok(events.includes('mail_webhook.signature.verified'));
+    assert.ok(events.includes('mail_webhook.recipient.resolved'));
+    assert.ok(events.includes('mail_webhook.body.selected'));
+    assert.ok(events.includes('mail_webhook.message.prepared'));
+    assert.ok(events.includes('line.push.started'));
+    assert.ok(events.includes('line.push.succeeded'));
+    assert.strictEqual(resolvedLog.lineRecipientKey.length, 12);
+    assertNoSensitiveLogContent(logger);
+  }
+
+  {
+    const logger = createCaptureLogger();
+    const { app } = createWebhookTestApp({
+      logger,
+      pushMessage: async () => {
+        const error = new Error('LINE API failed');
+        error.statusCode = 503;
+        error.headers = new Map([['x-line-request-id', 'line-request-id']]);
+        throw error;
+      },
+    });
+
+    const res = await postMailWebhook(app);
+
+    assert.strictEqual(res.status, 502);
+    assert.strictEqual(res.body.error.code, 'LINE_PUSH_FAILED');
+    assert.ok(getEvents(logger).includes('line.push.failed'));
+    assertNoSensitiveLogContent(logger);
+  }
+
+  console.log('mail webhook observability tests passed');
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/test/mail-webhook-observability.test.js
+++ b/test/mail-webhook-observability.test.js
@@ -3,13 +3,13 @@ const express = require('express');
 const { Iconv } = require('iconv');
 const request = require('supertest');
 const {
-  createMailWebhookHandler,
   decodeAndConvertMailPart,
 } = require('../lib/mail-webhook');
 const { createErrorMiddleware } = require('../lib/errors');
 const {
   createLogCorrelationId,
 } = require('../lib/logger');
+const { createWebhookRoutes } = require('../routes/webhook-routes');
 
 const createCaptureLogger = () => {
   const entries = [];
@@ -42,7 +42,7 @@ const createWebhookTestApp = ({
     req.requestId = 'test-request-id';
     next();
   });
-  app.post('/mail-webhook', createMailWebhookHandler({
+  app.use(createWebhookRoutes({
     db: {
       getEnabledRecipientByEmail: async () => ({
         line_recipient_id: 'U1234567890abcdef',
@@ -54,6 +54,14 @@ const createWebhookTestApp = ({
     mqttPublish: null,
     logger: resolvedLogger,
     verifyInboundParseWebhookSignature,
+    mailWebhookRateLimit: {
+      windowMs: 60 * 1000,
+      limit: 300,
+    },
+    lineWebhookMiddleware: (req, res, next) => {
+      req.body = { events: [] };
+      next();
+    },
   }));
   app.use(createErrorMiddleware());
 


### PR DESCRIPTION
## 概要
- logger を常時 JSON 出力に変更し、info は stdout、warn/error は stderr に振り分け
- mail webhook と LINE push の段階ログを追加し、requestId と短縮相関キーで追跡可能に変更
- charset 実変換、invalid charsets JSON の継続処理、ログ秘匿テストを追加
- docs にメール未達、LINE push 失敗、文字化け時の最小 runbook を追加

## 確認
- `mise exec -- node test/logger.test.js`
- `mise exec -- node test/mail-webhook-observability.test.js`
- `env CI=true mise exec -- pnpm test`

補足: sandbox 内の通常実行では supertest の listen が EPERM になったため、フルテストは権限付きで再実行して通過確認しました。
