### PR TITLE
Fix CodeQL session cookie hardening

### DIFF
--- a/app/create-app.js
+++ b/app/create-app.js
@@ -65,30 +65,13 @@ const createHelpers = ({
   };
 };
 
-const createSessionOptions = ({
-  sessionOptions,
-  allowInsecureSessionCookie,
-}) => {
-  const secureSessionOptions = {
-    ...sessionOptions,
-    cookie: {
-      ...(sessionOptions.cookie || {}),
-      secure: true,
-    },
-  };
-
-  if (!allowInsecureSessionCookie) {
-    return secureSessionOptions;
-  }
-
-  return {
-    ...secureSessionOptions,
-    cookie: {
-      ...secureSessionOptions.cookie,
-      secure: Boolean(sessionOptions.cookie && sessionOptions.cookie.secure),
-    },
-  };
-};
+const createSessionOptions = ({ sessionOptions }) => ({
+  ...sessionOptions,
+  cookie: {
+    ...(sessionOptions.cookie || {}),
+    secure: true,
+  },
+});
 
 const createApp = ({
   rootDir,
@@ -103,7 +86,6 @@ const createApp = ({
   const isProduction = app.get('env') === 'production';
   const sessionOptions = createSessionOptions({
     sessionOptions: config.sessionOptions,
-    allowInsecureSessionCookie: config.allowInsecureSessionCookie,
   });
   const csrf = doubleCsrf({
     getSecret: () => process.env.CSRF_SECRET || sessionOptions.secret,

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -8,7 +8,7 @@
 - 未認証時の API 応答: 主に 401
 - 状態変更 API は csrf-csrf の CSRF トークンが必須（`X-CSRF-Token` ヘッダ）
 - セッション Cookie 名: `mail_to_linemsg.sid`
-- セッション Cookie 属性: `httpOnly=true`、`sameSite=lax`、`secure` は production で有効
+- セッション Cookie 属性: `httpOnly=true`、`sameSite=lax`、`secure=true`
 
 ### GET /api/csrf-token
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ejs": "^5.0.2",
     "email-addresses": "^5.0.0",
     "express": "^5.2.1",
-    "express-rate-limit": "^8.4.1",
+    "express-rate-limit": "^8.5.0",
     "express-session": "^1.18.2",
     "helmet": "^8.1.0",
     "html-to-text": "^9.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^5.2.1
         version: 5.2.1
       express-rate-limit:
-        specifier: ^8.4.1
-        version: 8.4.1(express@5.2.1)
+        specifier: ^8.5.0
+        version: 8.5.0(express@5.2.1)
       express-session:
         specifier: ^1.18.2
         version: 1.19.0
@@ -806,8 +806,8 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  express-rate-limit@8.4.1:
-    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+  express-rate-limit@8.5.0:
+    resolution: {integrity: sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -2747,7 +2747,7 @@ snapshots:
 
   events@3.3.0: {}
 
-  express-rate-limit@8.4.1(express@5.2.1):
+  express-rate-limit@8.5.0(express@5.2.1):
     dependencies:
       express: 5.2.1
       ip-address: 10.1.0

--- a/test/codeql-fixes.test.js
+++ b/test/codeql-fixes.test.js
@@ -105,20 +105,15 @@ const run = async () => {
           secure: false,
         },
       },
-      allowInsecureSessionCookie: false,
     });
     assert.strictEqual(secureOptions.cookie.secure, true);
 
-    const insecureOptions = createSessionOptions({
+    const defaultCookieOptions = createSessionOptions({
       sessionOptions: {
         secret: 'test-session-secret',
-        cookie: {
-          secure: false,
-        },
       },
-      allowInsecureSessionCookie: true,
     });
-    assert.strictEqual(insecureOptions.cookie.secure, false);
+    assert.strictEqual(defaultCookieOptions.cookie.secure, true);
   }
 
   {
@@ -174,18 +169,6 @@ const run = async () => {
     const limitedRes = await request(app).get('/callback');
     assert.strictEqual(limitedRes.status, 429);
     assert.match(limitedRes.text, /Auth rate limit exceeded\./);
-  }
-
-  {
-    const app = createTestApp({
-      config: {
-        allowInsecureSessionCookie: true,
-      },
-    });
-    const res = await request(app).get('/auth');
-    assert.strictEqual(res.status, 302);
-    assert.ok(res.headers['set-cookie']);
-    assert.ok(res.headers['set-cookie'].some(cookie => !cookie.includes(' Secure')));
   }
 
   {


### PR DESCRIPTION
## 概要
- session cookie の test-only insecure override を削除し、`secure=true` を常に強制するようにしました
- CodeQL 回帰テストを `secure=true` 前提へ更新しました
- `docs/api-reference.md` の session cookie 属性説明を実装に合わせました
- override は使わず、`express-rate-limit` は最新の `8.5.0` へ追従しました

## 注意
- `express-rate-limit@8.5.0` は現時点でも `ip-address@10.1.0` に依存しているため、Dependabot #68 はこの PR だけでは閉じない可能性があります

## 確認
- `mise exec -- pnpm install --lockfile-only`
- `mise exec -- pnpm test`
- `docker build --target test -t mail-to-linemsg:test .`