### PR TITLE
Fix CodeQL session cookie detection

### DIFF
--- a/app/create-app.js
+++ b/app/create-app.js
@@ -87,6 +87,13 @@ const createApp = ({
   const sessionOptions = createSessionOptions({
     sessionOptions: config.sessionOptions,
   });
+  const secureSessionMiddleware = session({
+    ...sessionOptions,
+    cookie: {
+      ...sessionOptions.cookie,
+      secure: true,
+    },
+  });
   const csrf = doubleCsrf({
     getSecret: () => process.env.CSRF_SECRET || sessionOptions.secret,
     getSessionIdentifier: (req) => req.sessionID || '',
@@ -116,7 +123,7 @@ const createApp = ({
 
   app
     .use(logger.createRequestLogger())
-    .use(session(sessionOptions))
+    .use(secureSessionMiddleware)
     .use(cookieParser(sessionOptions.secret))
     .use(helmet(config.helmetOption))
     .use(createWebhookRoutes({


### PR DESCRIPTION
## 概要
- `express-session` に渡す options object の中で `cookie.secure=true` を明示しました
- 実行時の session cookie hardening は維持しつつ、CodeQL が secure cookie 設定を追える形にしました

## 確認
- `mise exec -- pnpm test`
- `docker build --target test -t mail-to-linemsg:test .`