### PR TITLE
Add Qdrant retrieval workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ fly.toml
 .local/
 inbound-parse-webhook-private.pem
 inbound-parse-webhook-public.pem
+artifacts/
+.gstack/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS
+
+## Repo Search
+
+When investigating this repository, prefer Qdrant MCP search before workspace full-text search.
+
+Start with qdrant-find using the templates in docs/QDRANT_QUERY_TEMPLATES.md.
+
+Use two-step retrieval when possible: first by feature intent, then by links tokens such as belongs_to, tested_by, related_doc, and imports.
+
+Use workspace full-text search only for exact symbol checks, line-level verification, or when Qdrant is unavailable, stale, or returns weak results.
+
+If recent changes may not be indexed yet, run the refresh and validation workflow from docs/QDRANT_QUERY_TEMPLATES.md before relying on retrieval.

--- a/docs/QDRANT_QUERY_TEMPLATES.md
+++ b/docs/QDRANT_QUERY_TEMPLATES.md
@@ -1,0 +1,88 @@
+# Qdrant Query Templates
+
+このファイルは qdrant-find 用の検索テンプレ集。
+目的は「毎回ゼロからクエリを考えない」こと。
+
+## 1. アプリ全体仕様
+
+- `mail-to-linemsg webhook line messaging mqtt flow`
+- `sendgrid inbound parse webhook contract required fields`
+- `mail routing local part recipient mapping postgres`
+
+## 2. メール解析
+
+- `mail webhook multipart parser transfer-encoding decode`
+- `charset fallback utf8 iso-2022-jp windows-31j`
+- `html to text normalization line message body`
+
+## 3. Webhook 署名
+
+- `inbound parse webhook signature ecdsa p256 verify`
+- `X-Twilio-Email-Event-Webhook-Signature verification`
+- `public key pem verify timestamp payload`
+
+## 4. LINE/MQTT 送信
+
+- `line messaging push api recipient id mapping`
+- `mqtt publish payload subject json`
+- `mail text summary formatting for line`
+
+## 5. テスト探索
+
+- `mail-webhook rate limit test cases`
+- `multipart parse e2e mail samples test`
+- `signature verification unit test`
+
+## 6. 運用・デプロイ
+
+- `fly deploy required env vars`
+- `session security csrf cookie settings`
+- `postgres schema recipient mapping`
+
+## 7. 差分追跡クエリ
+
+- `recent changes in lib routes app`
+- `new tests for mail webhook parsing`
+- `qdrant diff targets summary`
+
+## 8. 擬似グラフ2段検索テンプレ
+
+1段目で機能を引き、2段目で links 語彙を使って辿る。
+
+- 解析系
+- 1段目: `mail webhook multipart parse transfer-encoding charset fallback`
+- 2段目: `belongs_to:file:lib/mail-webhook.js tested_by:file:test/e2e-mail-samples.test.js related_doc:file:docs/system-overview.md`
+- 署名系
+- 1段目: `inbound parse webhook signature ecdsa p256 verification`
+- 2段目: `belongs_to:file:lib/inbound-parse-webhook-signature.js tested_by:file:test/inbound-parse-webhook-signature.test.js related_doc:file:docs/api-reference.md`
+- payload系
+- 1段目: `mail text normalization html to text line message payload`
+- 2段目: `belongs_to:file:lib/mail-text.js tested_by:file:test/mail-text.test.js related_doc:file:README.md`
+
+### links 語彙リファレンス
+
+- `imports:file:<path>`
+- `tested_by:file:<path>`
+- `related_doc:file:<path>`
+- `belongs_to:file:<path>`
+
+## クエリ作成ルール
+
+- 1クエリは「機能 + 制約 + 文脈」の3要素を入れる。
+- シンボル名が分かっているときは必ず含める。
+- エラー調査は `error message + symbol + expected behavior` で作る。
+
+## 自動運用コマンド
+
+- 差分抽出 + 投入バッチ生成
+- `pnpm run qdrant:refresh`
+- 同一 path は最新1件だけ残す（path-latest dedupe）
+- 出力: `artifacts/qdrant/diff-targets.json`, `artifacts/qdrant/store-batch.json`
+- 2段検索Gate検証
+- 事前に 2段目の検索結果を以下に保存する
+- `artifacts/qdrant/query-results/parse-hop2.txt`
+- `artifacts/qdrant/query-results/signature-hop2.txt`
+- `artifacts/qdrant/query-results/payload-hop2.txt`
+- 実行: `pnpm run qdrant:two-hop-validate`
+- Gate付き実行: `QDRANT_TWO_HOP_GATE=1 pnpm run qdrant:two-hop-validate`
+- 出力: `artifacts/qdrant/two-hop-validation.md`, `artifacts/qdrant/two-hop-validation.json`

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@
 - [api-reference.md](./api-reference.md): Webhook、OAuth、REST API の仕様
 - [data-model.md](./data-model.md): PostgreSQL テーブルとアプリ内の関連
 - [configuration.md](./configuration.md): 環境変数、起動方法、デプロイ周り
+- [QDRANT_QUERY_TEMPLATES.md](./QDRANT_QUERY_TEMPLATES.md): Qdrant 検索テンプレートと2段検索の運用手順
 
 図を先に見たいなら、[system-overview.md](./system-overview.md) のシーケンス図と [data-model.md](./data-model.md) の ER 図から入るのが早い。
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "node test/logger.test.js && node test/decode-transfer-encoding.test.js && node test/mail-text.test.js && node test/e2e-mail-samples.test.js && node test/csrf-protection.test.js && node test/session-security.test.js && node test/address-ownership.test.js && node test/inbound-parse-webhook-signature.test.js && node test/errors.test.js && node test/app-wiring.test.js && node test/codeql-fixes.test.js && node test/mail-webhook-rate-limit.test.js && node test/mail-webhook-observability.test.js"
+    "test": "node test/logger.test.js && node test/decode-transfer-encoding.test.js && node test/mail-text.test.js && node test/e2e-mail-samples.test.js && node test/csrf-protection.test.js && node test/session-security.test.js && node test/address-ownership.test.js && node test/inbound-parse-webhook-signature.test.js && node test/errors.test.js && node test/app-wiring.test.js && node test/codeql-fixes.test.js && node test/mail-webhook-rate-limit.test.js && node test/mail-webhook-observability.test.js",
+    "qdrant:diff-targets": "node scripts/qdrant-diff-targets.js",
+    "qdrant:store-batch": "node scripts/qdrant-store-batch.js",
+    "qdrant:two-hop-validate": "node scripts/qdrant-two-hop-validate.js",
+    "qdrant:refresh": "pnpm run qdrant:diff-targets && pnpm run qdrant:store-batch"
   },
   "engines": {
     "node": ">=20 <25"

--- a/scripts/qdrant-diff-targets.js
+++ b/scripts/qdrant-diff-targets.js
@@ -1,0 +1,357 @@
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const fsp = require('node:fs/promises');
+const path = require('node:path');
+
+function runGit(args, allowFail = false) {
+  try {
+    return execFileSync('git', args, {
+      cwd: process.cwd(),
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    if (allowFail) return '';
+    throw error;
+  }
+}
+
+function posixPath(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function fileExists(filePath) {
+  try {
+    return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
+  } catch (_error) {
+    return false;
+  }
+}
+
+function getBaseRef() {
+  const fromEnv = (process.env.QDRANT_BASE || '').trim();
+  if (fromEnv) return fromEnv;
+
+  const fromArg = (process.argv[2] || '').trim();
+  if (fromArg) return fromArg;
+
+  const refs = [
+    ['merge-base', 'origin/main', 'HEAD'],
+    ['merge-base', 'origin/master', 'HEAD'],
+  ];
+
+  for (const args of refs) {
+    const out = runGit(args, true);
+    if (out) return out;
+  }
+
+  return 'HEAD~1';
+}
+
+function getChangedPaths(baseRef) {
+  const compare = runGit(['diff', '--name-only', `${baseRef}..HEAD`], true)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const unstaged = runGit(['diff', '--name-only'], true)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const staged = runGit(['diff', '--name-only', '--cached'], true)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const untracked = runGit(['ls-files', '--others', '--exclude-standard'], true)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const seen = new Set();
+  const merged = [];
+  for (const p of [...compare, ...staged, ...unstaged, ...untracked]) {
+    const normalized = posixPath(p);
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    merged.push(normalized);
+  }
+
+  return merged;
+}
+
+function isTextLikeFile(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  const deny = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.ico', '.pdf', '.zip', '.db']);
+  if (deny.has(ext)) return false;
+  return true;
+}
+
+function classifySourceKind(filePath) {
+  const p = posixPath(filePath);
+  const ext = path.extname(p).toLowerCase();
+
+  if (p.startsWith('test/') || p.endsWith('.test.js')) return 'test';
+  if (p.startsWith('docs/') || p === 'README.md') return 'doc';
+  if (
+    p === 'package.json'
+    || p === 'mise.toml'
+    || p === 'pnpm-lock.yaml'
+    || p === 'pnpm-workspace.yaml'
+    || p === 'Dockerfile'
+    || p === 'Procfile'
+    || p === 'fly.toml'
+    || ext === '.sql'
+  ) return 'config';
+  if (p.startsWith('artifacts/') || p.startsWith('.local/')) return 'generated';
+  if (ext === '.js' || ext === '.json' || ext === '.ejs' || ext === '.css' || ext === '.md') return 'source';
+  return 'other';
+}
+
+function pickStrategy(lineCount, sourceKind) {
+  if (sourceKind === 'generated' || sourceKind === 'other') return 'summary';
+  if (sourceKind === 'doc') return lineCount <= 700 ? 'full' : 'summary';
+  return lineCount <= 900 ? 'full' : 'summary';
+}
+
+function splitLines(text) {
+  return text.replace(/\r\n/g, '\n').split('\n');
+}
+
+function extractImports(filePath, content) {
+  const imports = new Set();
+  const requireRegex = /require\(['"]([^'"]+)['"]\)/g;
+  const importRegex = /from\s+['"]([^'"]+)['"]/g;
+
+  for (const regex of [requireRegex, importRegex]) {
+    let m = regex.exec(content);
+    while (m) {
+      const spec = m[1];
+      if (spec && spec.startsWith('.')) {
+        const resolved = resolveRelativeImport(filePath, spec);
+        if (resolved) imports.add(resolved);
+      }
+      m = regex.exec(content);
+    }
+  }
+
+  return [...imports].sort();
+}
+
+function resolveRelativeImport(fromFilePath, specifier) {
+  const base = path.resolve(process.cwd(), path.dirname(fromFilePath), specifier);
+  const candidates = [
+    base,
+    `${base}.js`,
+    `${base}.json`,
+    path.join(base, 'index.js'),
+  ];
+
+  for (const c of candidates) {
+    if (fileExists(c)) {
+      return posixPath(path.relative(process.cwd(), c));
+    }
+  }
+
+  return null;
+}
+
+function extractExports(content) {
+  const exportsFound = new Set();
+
+  const namedExportRegex = /exports\.([A-Za-z0-9_$]+)/g;
+  let m = namedExportRegex.exec(content);
+  while (m) {
+    exportsFound.add(m[1]);
+    m = namedExportRegex.exec(content);
+  }
+
+  const objectExportRegex = /module\.exports\s*=\s*\{([\s\S]*?)\};?/g;
+  m = objectExportRegex.exec(content);
+  while (m) {
+    const body = m[1] || '';
+    body
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .forEach((name) => {
+        const key = name.split(':')[0].trim();
+        if (key) exportsFound.add(key);
+      });
+    m = objectExportRegex.exec(content);
+  }
+
+  return [...exportsFound].sort();
+}
+
+function extractFunctionSymbols(content) {
+  const symbols = new Set();
+  const fnDecl = /(?:^|\n)\s*(?:async\s+)?function\s+([A-Za-z0-9_$]+)\s*\(/g;
+  let m = fnDecl.exec(content);
+  while (m) {
+    symbols.add(m[1]);
+    m = fnDecl.exec(content);
+  }
+
+  const constFn = /(?:^|\n)\s*const\s+([A-Za-z0-9_$]+)\s*=\s*(?:async\s*)?\(/g;
+  m = constFn.exec(content);
+  while (m) {
+    symbols.add(m[1]);
+    m = constFn.exec(content);
+  }
+
+  return [...symbols].sort().slice(0, 40);
+}
+
+function inferTestPath(filePath) {
+  const ext = path.extname(filePath);
+  const stem = path.basename(filePath, ext);
+  const candidate = path.join('test', `${stem}.test.js`);
+  return fileExists(path.join(process.cwd(), candidate)) ? posixPath(candidate) : null;
+}
+
+function inferRelatedDoc(filePath) {
+  const p = posixPath(filePath);
+  if (p.startsWith('docs/')) return p;
+  if (p.startsWith('lib/') || p.startsWith('routes/') || p.startsWith('app/')) return 'docs/system-overview.md';
+  return 'README.md';
+}
+
+function buildSearchHints(filePath, content) {
+  const hints = new Set();
+  const base = path.basename(filePath);
+  const stem = base.replace(path.extname(base), '');
+  hints.add(`path:${filePath}`);
+  hints.add(`file:${base}`);
+  if (stem) hints.add(`symbol:${stem}`);
+
+  for (const symbol of extractFunctionSymbols(content).slice(0, 6)) {
+    hints.add(`symbol:${symbol}`);
+  }
+
+  return [...hints];
+}
+
+function toMarkdown(report) {
+  const lines = [];
+  lines.push('# Qdrant Diff Targets');
+  lines.push('');
+  lines.push(`- Generated: ${report.generatedAt}`);
+  lines.push(`- Base Ref: ${report.baseRef}`);
+  lines.push(`- Targets: ${report.totalTargets} (full=${report.fullTargets}, summary=${report.summaryTargets})`);
+  lines.push(`- Nodes: file=${report.fileNodes}, symbol=${report.symbolNodes}`);
+  lines.push('');
+  lines.push('| Node Type | Strategy | Path | Reason |');
+  lines.push('|---|---|---|---|');
+
+  for (const target of report.targets) {
+    const reason = target.reason.replace(/\|/g, '/');
+    lines.push(`| ${target.nodeType} | ${target.strategy} | ${target.path} | ${reason} |`);
+  }
+
+  return lines.join('\n');
+}
+
+async function buildTargets(changedPaths) {
+  const targets = [];
+
+  for (const changedPath of changedPaths) {
+    const abs = path.join(process.cwd(), changedPath);
+    if (!fileExists(abs) || !isTextLikeFile(changedPath)) continue;
+
+    let content = '';
+    try {
+      content = await fsp.readFile(abs, 'utf-8');
+    } catch (_error) {
+      continue;
+    }
+
+    const lineCount = splitLines(content).length;
+    const sourceKind = classifySourceKind(changedPath);
+    const strategy = pickStrategy(lineCount, sourceKind);
+    const imports = extractImports(changedPath, content);
+    const exportsFound = extractExports(content);
+    const searchHints = buildSearchHints(changedPath, content);
+
+    const links = new Set();
+    links.add(`belongs_to:file:${changedPath}`);
+
+    const relatedDoc = inferRelatedDoc(changedPath);
+    if (relatedDoc) links.add(`related_doc:file:${relatedDoc}`);
+
+    const testPath = inferTestPath(changedPath);
+    if (testPath) links.add(`tested_by:file:${testPath}`);
+
+    for (const imported of imports) {
+      links.add(`imports:file:${imported}`);
+    }
+
+    targets.push({
+      nodeType: 'file',
+      nodeId: `file:${changedPath}`,
+      path: changedPath,
+      lineCount,
+      strategy,
+      reason: `changed ${sourceKind} file`,
+      sourceKind,
+      links: [...links],
+      searchHints,
+      imports,
+      exports: exportsFound,
+    });
+
+    const symbols = extractFunctionSymbols(content);
+    for (const symbolName of symbols) {
+      targets.push({
+        nodeType: 'symbol',
+        nodeId: `symbol:${changedPath}#${symbolName}`,
+        path: changedPath,
+        lineCount,
+        strategy: 'summary',
+        reason: `symbol ${symbolName} in changed file`,
+        sourceKind,
+        links: [`belongs_to:file:${changedPath}`, ...(testPath ? [`tested_by:file:${testPath}`] : [])],
+        searchHints: [`symbol:${symbolName}`, `path:${changedPath}`],
+        symbolName,
+        parentPath: changedPath,
+      });
+    }
+  }
+
+  return targets;
+}
+
+async function main() {
+  const baseRef = getBaseRef();
+  const changedPaths = getChangedPaths(baseRef);
+  const targets = await buildTargets(changedPaths);
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    baseRef,
+    totalTargets: targets.length,
+    fullTargets: targets.filter((t) => t.strategy === 'full').length,
+    summaryTargets: targets.filter((t) => t.strategy === 'summary').length,
+    totalNodes: targets.length,
+    fileNodes: targets.filter((t) => t.nodeType === 'file').length,
+    symbolNodes: targets.filter((t) => t.nodeType === 'symbol').length,
+    targets,
+  };
+
+  const outDir = path.join(process.cwd(), 'artifacts', 'qdrant');
+  const outJson = path.join(outDir, 'diff-targets.json');
+  const outMd = path.join(outDir, 'diff-targets.md');
+
+  await fsp.mkdir(outDir, { recursive: true });
+  await fsp.writeFile(outJson, `${JSON.stringify(report, null, 2)}\n`, 'utf-8');
+  await fsp.writeFile(outMd, `${toMarkdown(report)}\n`, 'utf-8');
+
+  console.log(`[qdrant] diff targets: ${path.relative(process.cwd(), outJson)}`);
+  console.log(`[qdrant] base=${baseRef} files=${report.fileNodes} symbols=${report.symbolNodes} total=${report.totalTargets}`);
+}
+
+main().catch((error) => {
+  console.error('[qdrant] failed to generate diff targets', error);
+  process.exitCode = 1;
+});

--- a/scripts/qdrant-store-batch.js
+++ b/scripts/qdrant-store-batch.js
@@ -1,0 +1,138 @@
+const fsp = require('node:fs/promises');
+const path = require('node:path');
+
+function metadataPath(item) {
+  const raw = item && item.metadata ? item.metadata.path : '';
+  return typeof raw === 'string' ? raw : '';
+}
+
+function latestOnlyByPath(items) {
+  const pathToItem = new Map();
+  for (const item of items) {
+    const key = metadataPath(item);
+    if (!key) continue;
+    if (pathToItem.has(key)) {
+      pathToItem.delete(key);
+    }
+    pathToItem.set(key, item);
+  }
+  return [...pathToItem.values()];
+}
+
+async function readJson(filePath) {
+  const raw = await fsp.readFile(filePath, 'utf-8');
+  return JSON.parse(raw);
+}
+
+function repoNameFromCwd(cwd) {
+  return path.basename(cwd);
+}
+
+function compactSummary(target) {
+  const lines = [];
+  lines.push(`repo: ${repoNameFromCwd(process.cwd())}`);
+  lines.push(`nodeType: ${target.nodeType}`);
+  lines.push(`nodeId: ${target.nodeId}`);
+  lines.push(`path: ${target.path}`);
+  lines.push(`strategy: ${target.strategy}`);
+  lines.push(`sourceKind: ${target.sourceKind}`);
+  lines.push(`lineCount: ${target.lineCount}`);
+  if (target.symbolName) lines.push(`symbolName: ${target.symbolName}`);
+  if (target.parentPath) lines.push(`parentPath: ${target.parentPath}`);
+  if (target.links && target.links.length > 0) lines.push(`links: ${target.links.join(', ')}`);
+  if (target.searchHints && target.searchHints.length > 0) lines.push(`searchHints: ${target.searchHints.join(', ')}`);
+  if (target.imports && target.imports.length > 0) lines.push(`imports: ${target.imports.join(', ')}`);
+  if (target.exports && target.exports.length > 0) lines.push(`exports: ${target.exports.join(', ')}`);
+  lines.push('');
+  lines.push('summary:');
+  lines.push(`- ${target.reason}`);
+  return lines.join('\n');
+}
+
+function normalizeContent(content) {
+  return content.replace(/\r\n/g, '\n').trimEnd();
+}
+
+async function toBatchItem(target) {
+  const repo = repoNameFromCwd(process.cwd());
+  const metadata = {
+    repo,
+    path: target.path,
+    nodeType: target.nodeType,
+    nodeId: target.nodeId,
+    strategy: target.strategy,
+    sourceKind: target.sourceKind,
+    lineCount: target.lineCount,
+    links: target.links || [],
+    searchHints: target.searchHints || [],
+  };
+
+  if (target.symbolName) metadata.symbolName = target.symbolName;
+  if (target.parentPath) metadata.parentPath = target.parentPath;
+  if (target.imports && target.imports.length > 0) metadata.imports = target.imports;
+  if (target.exports && target.exports.length > 0) metadata.exports = target.exports;
+
+  if (target.nodeType === 'file' && target.strategy === 'full') {
+    const raw = await fsp.readFile(path.join(process.cwd(), target.path), 'utf-8');
+    const body = normalizeContent(raw);
+    const information = [
+      `repo: ${repo}`,
+      `path: ${target.path}`,
+      `language: ${path.extname(target.path).slice(1) || 'text'}`,
+      'kind: source_code',
+      '',
+      body,
+    ].join('\n');
+    return { information, metadata };
+  }
+
+  const information = compactSummary(target);
+  return { information, metadata };
+}
+
+async function main() {
+  const inPath = (process.env.QDRANT_DIFF_TARGETS_PATH || '').trim()
+    || path.join(process.cwd(), 'artifacts', 'qdrant', 'diff-targets.json');
+  const outPath = (process.env.QDRANT_STORE_BATCH_PATH || '').trim()
+    || path.join(process.cwd(), 'artifacts', 'qdrant', 'store-batch.json');
+
+  const report = await readJson(inPath);
+  const rawItems = [];
+
+  for (const target of report.targets || []) {
+    try {
+      rawItems.push(await toBatchItem(target));
+    } catch (_error) {
+      // Skip unreadable files to keep batch generation resilient.
+    }
+  }
+
+  const items = latestOnlyByPath(rawItems);
+
+  const batch = {
+    generatedAt: new Date().toISOString(),
+    repo: repoNameFromCwd(process.cwd()),
+    baseRef: report.baseRef,
+    dedupeMode: 'path-latest',
+    totalItemsBeforeDedupe: rawItems.length,
+    totalItems: items.length,
+    fileFullItems: items.filter((item) => item.metadata.nodeType === 'file' && item.metadata.strategy === 'full').length,
+    fileSummaryItems: items.filter((item) => item.metadata.nodeType === 'file' && item.metadata.strategy === 'summary').length,
+    symbolItems: items.filter((item) => item.metadata.nodeType === 'symbol').length,
+    droppedByDedupe: rawItems.length - items.length,
+    items,
+  };
+
+  await fsp.mkdir(path.dirname(outPath), { recursive: true });
+  await fsp.writeFile(outPath, `${JSON.stringify(batch, null, 2)}\n`, 'utf-8');
+
+  console.log(`[qdrant] batch generated: ${path.relative(process.cwd(), outPath)}`);
+  console.log(`[qdrant] dedupe=${batch.dedupeMode} before=${batch.totalItemsBeforeDedupe} after=${batch.totalItems} dropped=${batch.droppedByDedupe}`);
+  console.log(`[qdrant] total=${batch.totalItems} full=${batch.fileFullItems} summary=${batch.fileSummaryItems} symbol=${batch.symbolItems}`);
+  console.log('[qdrant] next: ingest each item.information + item.metadata via qdrant-store');
+}
+
+main().catch((error) => {
+  console.error('[qdrant] failed to generate store batch', error);
+  process.exitCode = 1;
+});

--- a/scripts/qdrant-two-hop-validate.js
+++ b/scripts/qdrant-two-hop-validate.js
@@ -1,0 +1,133 @@
+const fsp = require('node:fs/promises');
+const path = require('node:path');
+
+const QUERY_RESULTS_DIR = path.join(process.cwd(), 'artifacts', 'qdrant', 'query-results');
+
+const THEMES = [
+  {
+    id: 'parse',
+    hop1Query: 'mail webhook multipart parse transfer-encoding charset fallback',
+    hop2Query: 'belongs_to:file:lib/mail-webhook.js tested_by:file:test/e2e-mail-samples.test.js related_doc:file:docs/system-overview.md',
+    hop2File: path.join(QUERY_RESULTS_DIR, 'parse-hop2.txt'),
+    requiredPaths: ['lib/mail-webhook.js', 'test/e2e-mail-samples.test.js', 'docs/system-overview.md'],
+  },
+  {
+    id: 'signature',
+    hop1Query: 'inbound parse webhook signature ecdsa p256 verification',
+    hop2Query: 'belongs_to:file:lib/inbound-parse-webhook-signature.js tested_by:file:test/inbound-parse-webhook-signature.test.js related_doc:file:docs/api-reference.md',
+    hop2File: path.join(QUERY_RESULTS_DIR, 'signature-hop2.txt'),
+    requiredPaths: ['lib/inbound-parse-webhook-signature.js', 'test/inbound-parse-webhook-signature.test.js', 'docs/api-reference.md'],
+  },
+  {
+    id: 'payload',
+    hop1Query: 'mail text normalization html to text line message payload',
+    hop2Query: 'belongs_to:file:lib/mail-text.js tested_by:file:test/mail-text.test.js related_doc:file:README.md',
+    hop2File: path.join(QUERY_RESULTS_DIR, 'payload-hop2.txt'),
+    requiredPaths: ['lib/mail-text.js', 'test/mail-text.test.js', 'README.md'],
+  },
+];
+
+function tryParseJsonAsText(raw) {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return raw;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return JSON.stringify(parsed);
+  } catch (_error) {
+    return raw;
+  }
+}
+
+function toMarkdown(report) {
+  const lines = [];
+  lines.push('# Qdrant Two-Hop Validation');
+  lines.push('');
+  lines.push(`- Generated: ${report.generatedAt}`);
+  lines.push('- Scope: 3 themes x 2-hop queries (1st intent query + 2nd links query)');
+  lines.push('');
+  lines.push('## Query Set');
+  lines.push('');
+
+  for (const theme of report.themes) {
+    lines.push(`### ${theme.id}`);
+    lines.push(`- Hop1: \`${theme.hop1Query}\``);
+    lines.push(`- Hop2: \`${theme.hop2Query}\``);
+    lines.push(`- Hop2 Result File: \`${path.relative(process.cwd(), theme.hop2File)}\``);
+    lines.push('');
+  }
+
+  lines.push('## Results');
+  lines.push('');
+  lines.push('| Theme | Required Path | Result |');
+  lines.push('|---|---|---|');
+  for (const check of report.checks) {
+    lines.push(`| ${check.theme} | ${check.requiredPath} | ${check.result} |`);
+  }
+  lines.push('');
+  lines.push('## Summary');
+  lines.push('');
+  lines.push(`- Total checks: ${report.totalChecks}`);
+  lines.push(`- Passed: ${report.passedChecks}`);
+  lines.push(`- Failed: ${report.failedChecks}`);
+  lines.push(`- Gate: ${report.gate}`);
+  return lines.join('\n');
+}
+
+async function main() {
+  const checks = [];
+
+  for (const theme of THEMES) {
+    let text = '';
+    try {
+      const raw = await fsp.readFile(theme.hop2File, 'utf-8');
+      text = tryParseJsonAsText(raw);
+    } catch (_error) {
+      text = '';
+    }
+
+    for (const requiredPath of theme.requiredPaths) {
+      const result = text.includes(requiredPath) ? 'PASS' : 'FAIL';
+      checks.push({
+        theme: theme.id,
+        hop2File: theme.hop2File,
+        requiredPath,
+        result,
+      });
+    }
+  }
+
+  const totalChecks = checks.length;
+  const passedChecks = checks.filter((check) => check.result === 'PASS').length;
+  const failedChecks = totalChecks - passedChecks;
+  const gate = failedChecks === 0 ? 'PASS' : 'FAIL';
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    totalChecks,
+    passedChecks,
+    failedChecks,
+    gate,
+    themes: THEMES,
+    checks,
+  };
+
+  const outDir = path.join(process.cwd(), 'artifacts', 'qdrant');
+  const outJson = path.join(outDir, 'two-hop-validation.json');
+  const outMd = path.join(outDir, 'two-hop-validation.md');
+  await fsp.mkdir(outDir, { recursive: true });
+  await fsp.writeFile(outJson, `${JSON.stringify(report, null, 2)}\n`, 'utf-8');
+  await fsp.writeFile(outMd, `${toMarkdown(report)}\n`, 'utf-8');
+
+  console.log(`[qdrant] validation: ${path.relative(process.cwd(), outMd)}`);
+  console.log(`[qdrant] checks=${totalChecks} pass=${passedChecks} fail=${failedChecks} gate=${gate}`);
+
+  if (process.env.QDRANT_TWO_HOP_GATE === '1' && gate === 'FAIL') {
+    console.error('[qdrant] gate failed (set QDRANT_TWO_HOP_GATE=1)');
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error('[qdrant] failed to validate two-hop results', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## 概要
Qdrant を使った実装検索フローを追加。

## 変更内容
- Qdrant 用スクリプトを追加
  - scripts/qdrant-diff-targets.js
  - scripts/qdrant-store-batch.js
  - scripts/qdrant-two-hop-validate.js
- package.json に実行スクリプトを追加
  - qdrant:diff-targets
  - qdrant:store-batch
  - qdrant:two-hop-validate
  - qdrant:refresh
- docs/QDRANT_QUERY_TEMPLATES.md を追加
- AGENTS.md に Qdrant 優先検索方針を追加
- docs/README.md に導線を追加
- .gitignore に artifacts/.gstack を追加

## 動作確認
- QDRANT_TWO_HOP_GATE=1 pnpm run qdrant:two-hop-validate
- pnpm test

## 補足
機微情報を除外/マスクした内容のみ Qdrant へ保存済み。