### PR TITLE
CI: DHI Community レジストリへの docker login を追加

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -22,6 +22,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Login to DHI Community Registry
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -31,6 +38,8 @@ jobs:
           FLY_APP: ${{ vars.FLY_APP }}
           FLY_PRIMARY_REGION: ${{ vars.FLY_PRIMARY_REGION }}
           LINE_LOGIN_CALLBACK_URL: ${{ vars.LINE_LOGIN_CALLBACK_URL }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           set -euo pipefail
           if [ -z "${FLY_API_TOKEN:-}" ]; then
@@ -41,6 +50,13 @@ jobs:
           for key in FLY_APP FLY_PRIMARY_REGION LINE_LOGIN_CALLBACK_URL; do
             if [ -z "${!key:-}" ]; then
               echo "Missing required variable: ${key}" >&2
+              exit 1
+            fi
+          done
+
+          for key in DOCKERHUB_USERNAME DOCKERHUB_TOKEN; do
+            if [ -z "${!key:-}" ]; then
+              echo "Missing required secret: ${key}" >&2
               exit 1
             fi
           done


### PR DESCRIPTION
## 変更の概要

`flyctl deploy --local-only` はランナー上のローカル Docker デーモンでビルドを実行する（Fly.io リモートビルダーは使用しない）。
`dhi.io/node:22-alpine-sfw-dev` の pull に認証が必要なため、`docker/login-action@v3` を使って `dhi.io` にログインするステップを追加する。

## 変更の理由・背景

**失敗ログ確認済み（Actions Run 27878113475）:**  
```
#2 ERROR: failed to authorize: failed to fetch anonymous token:
  unexpected status from GET request to https://dhi.io/token?...: 401 Unauthorized
```

`--local-only` でランナー上でビルドしていることを確認。ランナー上での `docker login dhi.io` が必要。

## 主な変更点

- **`.github/workflows/deploy-fly.yml`**
  - `Checkout` の直後に `Login to DHI Community Registry` ステップを追加
    - `docker/login-action@v3` で `dhi.io` にログイン
    - `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` シークレットを使用（他リポジトリと共通）
    - ジョブ終了時に自動ログアウト
  - `Validate required configuration` に `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` の存在チェックを追加

## 事前準備（手動作業）

リポジトリの **Settings > Secrets and variables > Actions** に以下のシークレットが登録済みであることを確認:

| Secret 名 | 内容 |
|-----------|------|
| `DOCKERHUB_USERNAME` | Docker Hub ユーザー名 |
| `DOCKERHUB_TOKEN` | Docker Hub PAT |

他リポジトリで登録済みであれば、共有されている場合は追加不要。

## テスト方法

1. シークレット登録確認後、このブランチを push して Actions を `workflow_dispatch` で手動実行
2. `Login to DHI Community Registry` ステップが成功し、`Deploy` ステップが `dhi.io` からイメージを pull できることを確認

## 関連 Issue

- PR #64（Dockerfile の DHI イメージ移行）のデプロイ対応