### PR TITLE
CI: docker login の対象を dhi.io から Docker Hub に修正

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -22,10 +22,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Login to DHI Community Registry
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          registry: dhi.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 


### PR DESCRIPTION
## 変更の概要

PR #65 の修正。`docker login dhi.io` では認証が機能しなかったため、Docker Hub にログインする形に変更。

## 原因

```
#2 ERROR: failed to authorize: failed to fetch anonymous token:
  unexpected status from GET request to https://dhi.io/token?...&service=registry.docker.io: 401 Unauthorized
```

`dhi.io` の auth チャレンジに `service=registry.docker.io` が含まれる（Docker Hub を認証サービスとして使用）。  
Docker BuildKit は `service=registry.docker.io` を検出すると **Docker Hub (`docker.io`) の認証情報**を使ってトークンを取得しようとする。  
PR #65 では `docker login dhi.io` を行っており、Docker Hub の認証情報が存在しなかったため anonymous リクエストになって 401 が発生。

## 修正

`docker/login-action@v3` の `registry: dhi.io` を削除。`registry:` を指定しないとデフォルトで Docker Hub にログインする。

## 根拠

ローカルビルドであることは確認済み（`docker host: 28.0.4 linux x86_64`）。  
`dhi.io` は Docker Hub サブスクリプション連携レジストリ（DHI = Docker Hardened Images）であり、認証は Docker Hub 経由で行われる。

## 関連

- PR #65（`docker login dhi.io` → 認証が機能しなかった）
- Actions Run 27878794344（`Login Succeeded!` と表示されるが build 401）