### PR TITLE
CI: docker pull でベースイメージを事前取得（認証診断＋キャッシュ）

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -28,6 +28,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Pull DHI base image
+        run: docker pull dhi.io/node:22-alpine-sfw-dev
+
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
 


### PR DESCRIPTION
## 変更の概要

`docker login` ステップの後、flyctl deploy の前に `docker pull dhi.io/node:22-alpine-sfw-dev` を追加。

## 背景・目的

PR #65（`docker login dhi.io`）・PR #66（`docker login docker.io`）共に `docker login` は `Login Succeeded!` を返したが、flyctl の BuildKit が依然として anonymous リクエストで 401 になった。

**仮説:** `docker/login-action@v3` が保存した認証情報を flyctl の BuildKit が参照できていない（`~/.docker/config.json` のパス差異、`credsStore` 設定等）。

**このPRの効果:**
1. **診断:** `docker pull` は Docker デーモンを直接使うため、認証情報が正しく使われるか確認できる。失敗すれば「認証情報自体が DHI にアクセスできない」と確定する
2. **ワークアラウンド:** `docker pull` 成功時は Docker デーモンのイメージキャッシュに入るため、flyctl の BuildKit もそれを利用できる

## 期待する結果

- `Pull DHI base image` ステップが成功 → 認証 OK、キャッシュ経由で Build も通過
- `Pull DHI base image` ステップが失敗 → Docker Hub アカウントの DHI アクセス権を要確認

## 関連

- PR #65 / #66（`docker login` のみではBuilt KitがAnonymousになる問題）