### PR TITLE
CI: docker/login-action を廃止し Docker CLI で直接 dhi.io にログイン

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -22,11 +22,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to DHI Community Registry
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          mkdir -p ~/.docker
+          # credsStore が設定されていると CI では credential helper が動作しないため除去する
+          if [ -f ~/.docker/config.json ]; then
+            jq 'del(.credsStore) | del(.credHelpers)' ~/.docker/config.json > /tmp/.docker-cfg-tmp.json
+            mv /tmp/.docker-cfg-tmp.json ~/.docker/config.json
+          else
+            echo '{}' > ~/.docker/config.json
+          fi
+          printf '%s' "$DOCKERHUB_TOKEN" | docker login dhi.io -u "$DOCKERHUB_USERNAME" --password-stdin
 
       - name: Pull DHI base image
         run: docker pull dhi.io/node:22-alpine-sfw-dev


### PR DESCRIPTION
## 変更の概要

`docker/login-action@v3` を廃止し、Docker CLI の `docker login` を直接使う方式に変更。

## 背景

`docker/login-action@v3` は内部で credential helper（`credsStore`）経由で認証情報を保存することがある。CI 環境では credential helper（`pass`、`secretservice` 等）が正常に動作しないため、後続の `docker pull` や flyctl の BuildKit が認証情報を読み取れない。

**これまでの失敗パターン:**
- PR #65: `docker login dhi.io`（action）→ Login Succeeded → flyctl が anonymous で 401
- PR #66: `docker login docker.io`（action）→ Login Succeeded → docker pull が 401
- PR #67: 同上 + `docker pull` 追加 → docker pull が unauthorized（`dhi.io` 認証なし）

## 変更内容

1. **`credsStore` / `credHelpers` を事前除去**: `~/.docker/config.json` から credential helper 設定を削除し、`config.json` への直接書き込みを保証する
2. **Docker CLI で直接ログイン**: `docker login dhi.io --password-stdin` で認証情報を `config.json` に直接保存
3. **`docker pull` で事前検証＆キャッシュ**: ログイン直後に pull を実行し認証確認とキャッシュウォームアップを行う

## 期待する動作

- `Login to DHI Community Registry` ステップで `~/.docker/config.json` に `dhi.io` の認証情報が直接書かれる
- `Pull DHI base image` が成功 → 認証 OK・キャッシュ済み
- flyctl の BuildKit も同じ `config.json` を参照して pull をスキップ or 認証済みで取得

## 関連

- PR #65 / #66 / #67（`docker/login-action` が CI で機能しなかった問題）