### PR TITLE
fix: brace-expansion を 1.1.13 に固定しDoS脆弱性を修正 (GHSA-f886-m6hf-6m8v)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   brace-expansion: 2.0.3
   flatted: 3.4.2
   filelist>minimatch: 5.1.8
-  minimatch@3.1.4>brace-expansion: 1.1.12
+  minimatch@3.1.4>brace-expansion: 1.1.13
   minimatch: 3.1.4
   table>ajv: 8.18.0
   form-data: 4.0.6
@@ -417,8 +417,8 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
   broker-factory@3.1.15:
     resolution: {integrity: sha512-ko+aWvgNuP49meGrdjUu7rC+Y+Wai3cCPxP3xWwHsHfehFjOh5ZQM2yC4gEB2UddeZ/YXhm0K1eG/L6fxym2Og==}
@@ -2236,7 +2236,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -3240,7 +3240,7 @@ snapshots:
 
   minimatch@3.1.4:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.13
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ overrides:
   "brace-expansion": "2.0.3"
   "flatted": "3.4.2"
   "filelist>minimatch": "5.1.8"
-  "minimatch@3.1.4>brace-expansion": "1.1.12"
+  "minimatch@3.1.4>brace-expansion": "1.1.13"
   "minimatch": "3.1.4"
   "table>ajv": "8.18.0"
   "form-data": "4.0.6"


### PR DESCRIPTION
## 変更の概要

Dependabot Alert #75 で報告された `brace-expansion` パッケージの DoS 脆弱性を修正します。

## 変更の理由/背景

- **CVE-2026-33750 / GHSA-f886-m6hf-6m8v** (CVSS 6.5 / Medium)
  - ゼロステップシーケンス `{1..2..0}` を渡すと `expand()` 内のループが無限に実行される
  - 約 3.5 秒のプロセスハング + 約 1.9 GB のメモリ消費が発生
  - CLI 引数や設定ファイルから untrusted な文字列を受け取るアプリケーション全般に影響
- `brace-expansion@1.1.12`（脆弱）→ `1.1.13`（修正済み）

## 主な変更点

- `pnpm-workspace.yaml` の `minimatch@3.1.4>brace-expansion` を `1.1.12` → `1.1.13` に更新

> **Note**: このブランチは PR #69（pnpm.overrides の pnpm-workspace.yaml への移行 + form-data 修正）をベースにしています。PR #69 のマージ後にこの PR の差分は brace-expansion の変更のみになります。

## テスト方法

```bash
# brace-expansion のバージョン確認
grep "brace-expansion" pnpm-lock.yaml | grep "1\.1\."
# → brace-expansion@1.1.13 と表示されること
```

## 関連 Issue

- Dependabot Alert #75: GHSA-f886-m6hf-6m8v (brace-expansion DoS)
- PR #69: pnpm.overrides 移行 + form-data 修正（このPRの前提）