### PR TITLE
Add Docker and GitHub Actions to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,20 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
# 概要
- Dependabotが対象にするエコシステムに、 `docker` と `github-actions` を追加

# コミット対象
- `.github/dependabot.yml` の `package-ecosystem` に `docker` と `github-actions` を追加
- `docker`エコシステムでは、 `node` のメジャーバージョンアップを勧告しない