### PR TITLE
feat: LINE/MQTT投稿を並列化し部分成功を207で返す

### DIFF
--- a/lib/mail-webhook.js
+++ b/lib/mail-webhook.js
@@ -449,13 +449,12 @@ const createMailWebhookHandler = ({
         failed,
       });
     }
+    // 全失敗。LINE は常時チャネルに含まれ、失敗時は AppError('LINE_PUSH_FAILED')
+    // を reject するため、その理由を投げてエラーミドルウェアで 502 にする。
     const lineFailure = results.find(
       (result, index) => result.status === 'rejected' && channels[index].name === 'line',
     );
-    if (lineFailure && lineFailure.reason instanceof AppError) {
-      throw lineFailure.reason;
-    }
-    throw new AppError('DELIVERY_FAILED', 'Failed to deliver message.', 502, { failed });
+    throw lineFailure.reason;
   } catch(e) {
     next(e);
   }

--- a/lib/mail-webhook.js
+++ b/lib/mail-webhook.js
@@ -17,6 +17,7 @@ const {
 } = require('./inbound-parse-webhook-signature');
 
 const mailWebhookMaxBytes = 30 * 1024 * 1024;
+const mqttPublishDeadlineMs = 500;
 const lineTextMessageMaxChars = 5000;
 const lineTextMessageTruncationMarker = '\r\n（省略）';
 const trackedMultipartFieldNames = new Set(['to', 'from', 'subject', 'charsets', 'text', 'html']);
@@ -190,6 +191,16 @@ const decodeAndConvertMailPart = ({
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const withDeadline = (promise, ms) => Promise.race([
+  promise,
+  new Promise((_, reject) => {
+    const timer = setTimeout(() => reject(new Error('MQTT publish deadline exceeded.')), ms);
+    if (timer.unref) {
+      timer.unref();
+    }
+  }),
+]);
+
 const shouldRetryLineError = (error) => {
   const statusCode = error && (error.statusCode || error.status);
   return !statusCode || statusCode >= 500;
@@ -331,77 +342,120 @@ const createMailWebhookHandler = ({
       charsAfter,
       truncated: charsAfter < charsBefore,
     });
-    logger.logInfo('line.push.started', {
-      requestId: req.requestId,
-      lineRecipientKey,
-    });
-    await retryAsync({
-      operation: () => msgbot.pushMessage({
-        to: recipient.line_recipient_id,
-        messages: [ { type: 'text', text: msgBody }, ],
-      }),
-      retries: 2,
-      initialDelayMs: 200,
-      shouldRetry: shouldRetryLineError,
-      onRetry: (error, attempt, delayMs) => {
-        logger.logWarn('line.push.retry', {
-          requestId: req.requestId,
-          attempt,
-          delayMs,
-          statusCode: error && (error.statusCode || error.status),
-        });
-      },
-    }).catch((err) => {
-      const lineRequestId = err && err.headers && typeof err.headers.get === 'function'
-        ? err.headers.get('x-line-request-id')
-        : undefined;
-      logger.logError('line.push.failed', {
-        requestId: req.requestId,
-        lineRecipientKey,
-        statusCode: err && (err.statusCode || err.status),
-        lineRequestId,
-        message: err && err.message,
-      });
-      throw new AppError('LINE_PUSH_FAILED', 'Failed to push message to LINE.', 502, {
-        statusCode: err && (err.statusCode || err.status),
-        lineRequestId,
-      });
-    });
-    logger.logInfo('line.push.succeeded', {
-      requestId: req.requestId,
-      lineRecipientKey,
-    });
-    if (mqttPublish !== null) {
-      logger.logInfo('mqtt.publish.started', {
-        requestId: req.requestId,
-        topic: mqttPublish.topic,
-      });
-      retryAsync({
-        operation: () => mqttPublish.publish(mailContent.subject),
-        retries: 2,
-        initialDelayMs: 200,
-        shouldRetry: shouldRetryMqttError,
-        onRetry: (error, attempt, delayMs) => {
-          logger.logWarn('mqtt.publish.retry', {
+    const channels = [
+      {
+        name: 'line',
+        run: async () => {
+          logger.logInfo('line.push.started', {
             requestId: req.requestId,
-            attempt,
-            delayMs,
-            message: error && error.message,
+            lineRecipientKey,
+          });
+          await retryAsync({
+            operation: () => msgbot.pushMessage({
+              to: recipient.line_recipient_id,
+              messages: [ { type: 'text', text: msgBody }, ],
+            }),
+            retries: 2,
+            initialDelayMs: 200,
+            shouldRetry: shouldRetryLineError,
+            onRetry: (error, attempt, delayMs) => {
+              logger.logWarn('line.push.retry', {
+                requestId: req.requestId,
+                attempt,
+                delayMs,
+                statusCode: error && (error.statusCode || error.status),
+              });
+            },
+          }).catch((err) => {
+            const lineRequestId = err && err.headers && typeof err.headers.get === 'function'
+              ? err.headers.get('x-line-request-id')
+              : undefined;
+            logger.logError('line.push.failed', {
+              requestId: req.requestId,
+              lineRecipientKey,
+              statusCode: err && (err.statusCode || err.status),
+              lineRequestId,
+              message: err && err.message,
+            });
+            throw new AppError('LINE_PUSH_FAILED', 'Failed to push message to LINE.', 502, {
+              statusCode: err && (err.statusCode || err.status),
+              lineRequestId,
+            });
+          });
+          logger.logInfo('line.push.succeeded', {
+            requestId: req.requestId,
+            lineRecipientKey,
           });
         },
-      }).then(() => {
-        logger.logInfo('mqtt.publish.succeeded', {
-          requestId: req.requestId,
-          topic: mqttPublish.topic,
-        });
-      }).catch((error) => {
-        logger.logError('mqtt.publish.failed', {
-          requestId: req.requestId,
-          message: error && error.message,
-        });
+      },
+    ];
+
+    if (mqttPublish != null) {
+      channels.push({
+        name: 'mqtt',
+        run: async () => {
+          logger.logInfo('mqtt.publish.started', {
+            requestId: req.requestId,
+            topic: mqttPublish.topic,
+          });
+          await withDeadline(retryAsync({
+            operation: () => mqttPublish.publish(mailContent.subject),
+            retries: 1,
+            initialDelayMs: 100,
+            shouldRetry: shouldRetryMqttError,
+            onRetry: (error, attempt, delayMs) => {
+              logger.logWarn('mqtt.publish.retry', {
+                requestId: req.requestId,
+                attempt,
+                delayMs,
+                message: error && error.message,
+              });
+            },
+          }), mqttPublishDeadlineMs).catch((error) => {
+            logger.logError('mqtt.publish.failed', {
+              requestId: req.requestId,
+              message: error && error.message,
+            });
+            throw error;
+          });
+          logger.logInfo('mqtt.publish.succeeded', {
+            requestId: req.requestId,
+            topic: mqttPublish.topic,
+          });
+        },
       });
     }
-    return res.sendStatus(200);
+
+    const results = await Promise.allSettled(channels.map((channel) => channel.run()));
+    const delivered = [];
+    const failed = [];
+    results.forEach((result, index) => {
+      (result.status === 'fulfilled' ? delivered : failed).push(channels[index].name);
+    });
+
+    if (failed.length === 0) {
+      return res.sendStatus(200);
+    }
+    if (delivered.length > 0) {
+      logger.logInfo('mail_webhook.partial_success', {
+        requestId: req.requestId,
+        delivered,
+        failed,
+      });
+      return res.status(207).json({
+        success: false,
+        requestId: req.requestId,
+        delivered,
+        failed,
+      });
+    }
+    const lineFailure = results.find(
+      (result, index) => result.status === 'rejected' && channels[index].name === 'line',
+    );
+    if (lineFailure && lineFailure.reason instanceof AppError) {
+      throw lineFailure.reason;
+    }
+    throw new AppError('DELIVERY_FAILED', 'Failed to deliver message.', 502, { failed });
   } catch(e) {
     next(e);
   }

--- a/mqtt-publish.js
+++ b/mqtt-publish.js
@@ -18,10 +18,30 @@ class Mqtt {
   }
 
   connect() {
-    if (!this.client || !this.client.connected) {
-      debug(`Connecting to ${this.uri} username=${this.username}`);
-      this.client = mqtt.connect(this.uri, { username: this.username, password: this.password });
+    if (this.client) {
+      // 接続中（CONNACK 前）でも client を共有し、同時 publish による
+      // 二重 connect / client 上書きを防ぐ。
+      return;
     }
+    debug(`Connecting to ${this.uri} username=${this.username}`);
+    const client = mqtt.connect(this.uri, {
+      username: this.username,
+      password: this.password,
+      connectTimeout: 2000,
+      reconnectPeriod: 0,
+    });
+    // error イベントにリスナーが無いと未処理 error でプロセスが落ちるため必ず張る。
+    client.on('error', (err) => {
+      debug(`MQTT client error: ${err && err.message}`);
+    });
+    // reconnectPeriod:0 では自動再接続しないため、切断時に参照を捨て、
+    // 次回 publish で新しい接続を張れるようにする。
+    client.on('close', () => {
+      if (this.client === client) {
+        this.client = null;
+      }
+    });
+    this.client = client;
   }
 
   async disconnect() {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "node test/logger.test.js && node test/decode-transfer-encoding.test.js && node test/mail-text.test.js && node test/e2e-mail-samples.test.js && node test/csrf-protection.test.js && node test/session-security.test.js && node test/address-ownership.test.js && node test/inbound-parse-webhook-signature.test.js && node test/errors.test.js && node test/app-wiring.test.js && node test/codeql-fixes.test.js && node test/mail-webhook-rate-limit.test.js && node test/mail-webhook-observability.test.js",
+    "test": "node test/logger.test.js && node test/decode-transfer-encoding.test.js && node test/mail-text.test.js && node test/e2e-mail-samples.test.js && node test/csrf-protection.test.js && node test/session-security.test.js && node test/address-ownership.test.js && node test/inbound-parse-webhook-signature.test.js && node test/errors.test.js && node test/app-wiring.test.js && node test/codeql-fixes.test.js && node test/mail-webhook-rate-limit.test.js && node test/mail-webhook-observability.test.js && node test/mail-webhook-delivery.test.js",
     "coverage": "c8 pnpm test",
     "qdrant:diff-targets": "node scripts/qdrant-diff-targets.js",
     "qdrant:store-batch": "node scripts/qdrant-store-batch.js",

--- a/test/mail-webhook-delivery.test.js
+++ b/test/mail-webhook-delivery.test.js
@@ -169,6 +169,30 @@ const run = async () => {
     assertNoSensitiveContent(res, logger);
   }
 
+  // 4b. Both fail, LINE error without headers and using `status` (not statusCode)
+  //     => 502 LINE_PUSH_FAILED (covers the no-headers / status-fallback branches)
+  {
+    const logger = createCaptureLogger();
+    const { app } = createWebhookTestApp({
+      logger,
+      pushMessage: async () => {
+        const error = new Error('LINE unavailable');
+        error.status = 503;
+        throw error;
+      },
+      mqttPublish: { topic: 'test/topic', publish: async () => { throw new Error('mqtt down'); } },
+    });
+    const res = await postMailWebhook(app);
+    const events = getEvents(logger);
+
+    assert.strictEqual(res.status, 502);
+    assert.strictEqual(res.body.error.code, 'LINE_PUSH_FAILED');
+    assert.strictEqual(res.body.error.details.statusCode, 503);
+    assert.strictEqual(res.body.error.details.lineRequestId, undefined);
+    assert.ok(events.includes('line.push.retry'));
+    assert.ok(events.includes('mqtt.publish.failed'));
+  }
+
   // 5. mqttPublish null + LINE ok => 200 (single channel never 207)
   {
     const logger = createCaptureLogger();

--- a/test/mail-webhook-delivery.test.js
+++ b/test/mail-webhook-delivery.test.js
@@ -1,0 +1,241 @@
+const assert = require('assert');
+const express = require('express');
+const request = require('supertest');
+const { createErrorMiddleware } = require('../lib/errors');
+const { createLogCorrelationId } = require('../lib/logger');
+const { createWebhookRoutes } = require('../routes/webhook-routes');
+
+const createCaptureLogger = () => {
+  const entries = [];
+  const capture = (level) => (event, details = {}) => {
+    entries.push({
+      level,
+      event,
+      ...details,
+    });
+  };
+
+  return {
+    entries,
+    createLogCorrelationId,
+    logError: capture('error'),
+    logInfo: capture('info'),
+    logWarn: capture('warn'),
+  };
+};
+
+const createWebhookTestApp = ({
+  logger,
+  pushMessage = async () => ({}),
+  mqttPublish = null,
+  verifyInboundParseWebhookSignature = () => {},
+} = {}) => {
+  const app = express();
+  const resolvedLogger = logger || createCaptureLogger();
+
+  app.use((req, res, next) => {
+    req.requestId = 'test-request-id';
+    next();
+  });
+  app.use(createWebhookRoutes({
+    db: {
+      getEnabledRecipientByEmail: async () => ({
+        line_recipient_id: 'U1234567890abcdef',
+      }),
+    },
+    msgbot: {
+      pushMessage,
+    },
+    mqttPublish,
+    logger: resolvedLogger,
+    verifyInboundParseWebhookSignature,
+    mailWebhookRateLimit: {
+      windowMs: 60 * 1000,
+      limit: 300,
+    },
+    lineWebhookMiddleware: (req, res, next) => {
+      req.body = { events: [] };
+      next();
+    },
+  }));
+  app.use(createErrorMiddleware());
+
+  return {
+    app,
+    logger: resolvedLogger,
+  };
+};
+
+const postMailWebhook = (app, fields = {}) => request(app)
+  .post('/mail-webhook')
+  .field('to', fields.to || 'notify@example.test')
+  .field('from', fields.from || 'sender-secret@example.test')
+  .field('subject', fields.subject || 'private subject')
+  .field('text', fields.text || 'private body');
+
+const getEvents = (logger) => logger.entries.map((entry) => entry.event);
+
+const failingPush = () => {
+  const error = new Error('LINE API failed');
+  error.statusCode = 503;
+  error.headers = new Map([['x-line-request-id', 'line-request-id']]);
+  throw error;
+};
+
+const assertNoSensitiveContent = (res, logger) => {
+  const serialized = JSON.stringify({ body: res.body, entries: logger.entries });
+  assert.doesNotMatch(serialized, /sender-secret@example\.test/);
+  assert.doesNotMatch(serialized, /private subject/);
+  assert.doesNotMatch(serialized, /private body/);
+  assert.doesNotMatch(serialized, /U1234567890abcdef/);
+  assert.doesNotMatch(serialized, /notify/);
+};
+
+const run = async () => {
+  // 1. LINE ok + MQTT ok => 200
+  {
+    const logger = createCaptureLogger();
+    let published;
+    const { app } = createWebhookTestApp({
+      logger,
+      mqttPublish: { topic: 'test/topic', publish: async (subject) => { published = subject; } },
+    });
+    const res = await postMailWebhook(app);
+    const events = getEvents(logger);
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(published, 'private subject');
+    assert.ok(events.includes('line.push.succeeded'));
+    assert.ok(events.includes('mqtt.publish.succeeded'));
+  }
+
+  // 2. LINE ok + MQTT fail => 207
+  {
+    const logger = createCaptureLogger();
+    const { app } = createWebhookTestApp({
+      logger,
+      mqttPublish: { topic: 'test/topic', publish: async () => { throw new Error('mqtt down'); } },
+    });
+    const res = await postMailWebhook(app);
+    const events = getEvents(logger);
+
+    assert.strictEqual(res.status, 207);
+    assert.match(res.headers['content-type'], /application\/json/);
+    assert.strictEqual(res.body.success, false);
+    assert.strictEqual(res.body.requestId, 'test-request-id');
+    assert.deepStrictEqual(res.body.delivered, ['line']);
+    assert.deepStrictEqual(res.body.failed, ['mqtt']);
+    assert.ok(events.includes('mqtt.publish.failed'));
+    assert.ok(events.includes('mail_webhook.partial_success'));
+    assertNoSensitiveContent(res, logger);
+  }
+
+  // 3. LINE fail + MQTT ok => 207 (MQTT runs even though LINE failed)
+  {
+    const logger = createCaptureLogger();
+    let published = false;
+    const { app } = createWebhookTestApp({
+      logger,
+      pushMessage: async () => failingPush(),
+      mqttPublish: { topic: 'test/topic', publish: async () => { published = true; } },
+    });
+    const res = await postMailWebhook(app);
+    const events = getEvents(logger);
+
+    assert.strictEqual(res.status, 207);
+    assert.strictEqual(published, true);
+    assert.deepStrictEqual(res.body.delivered, ['mqtt']);
+    assert.deepStrictEqual(res.body.failed, ['line']);
+    assert.ok(events.includes('mqtt.publish.succeeded'));
+    assert.ok(events.includes('line.push.failed'));
+    assertNoSensitiveContent(res, logger);
+  }
+
+  // 4. LINE fail + MQTT fail => 502 (LINE_PUSH_FAILED preserved)
+  {
+    const logger = createCaptureLogger();
+    const { app } = createWebhookTestApp({
+      logger,
+      pushMessage: async () => failingPush(),
+      mqttPublish: { topic: 'test/topic', publish: async () => { throw new Error('mqtt down'); } },
+    });
+    const res = await postMailWebhook(app);
+    const events = getEvents(logger);
+
+    assert.strictEqual(res.status, 502);
+    assert.strictEqual(res.body.error.code, 'LINE_PUSH_FAILED');
+    assert.ok(events.includes('line.push.failed'));
+    assert.ok(events.includes('mqtt.publish.failed'));
+    assertNoSensitiveContent(res, logger);
+  }
+
+  // 5. mqttPublish null + LINE ok => 200 (single channel never 207)
+  {
+    const logger = createCaptureLogger();
+    const { app } = createWebhookTestApp({ logger, mqttPublish: null });
+    const res = await postMailWebhook(app);
+
+    assert.strictEqual(res.status, 200);
+    assert.ok(getEvents(logger).includes('line.push.succeeded'));
+  }
+
+  // 6. mqttPublish null + LINE fail => 502 LINE_PUSH_FAILED
+  {
+    const logger = createCaptureLogger();
+    const { app } = createWebhookTestApp({
+      logger,
+      pushMessage: async () => failingPush(),
+      mqttPublish: null,
+    });
+    const res = await postMailWebhook(app);
+
+    assert.strictEqual(res.status, 502);
+    assert.strictEqual(res.body.error.code, 'LINE_PUSH_FAILED');
+  }
+
+  // 7. MQTT retry: fail once then succeed => 200, mqtt.publish.retry logged
+  {
+    const logger = createCaptureLogger();
+    let attempts = 0;
+    const { app } = createWebhookTestApp({
+      logger,
+      mqttPublish: {
+        topic: 'test/topic',
+        publish: async () => {
+          attempts += 1;
+          if (attempts === 1) {
+            throw new Error('transient');
+          }
+        },
+      },
+    });
+    const res = await postMailWebhook(app);
+    const events = getEvents(logger);
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(attempts, 2);
+    assert.ok(events.includes('mqtt.publish.retry'));
+    assert.ok(events.includes('mqtt.publish.succeeded'));
+  }
+
+  // 8. MQTT hangs => channel deadline fails it => 207 (no hang)
+  {
+    const logger = createCaptureLogger();
+    const { app } = createWebhookTestApp({
+      logger,
+      mqttPublish: { topic: 'test/topic', publish: () => new Promise(() => {}) },
+    });
+    const res = await postMailWebhook(app);
+
+    assert.strictEqual(res.status, 207);
+    assert.deepStrictEqual(res.body.delivered, ['line']);
+    assert.deepStrictEqual(res.body.failed, ['mqtt']);
+  }
+
+  console.log('mail webhook delivery tests passed');
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## 概要

メールWebhook（[lib/mail-webhook.js](lib/mail-webhook.js)）の送信先を「チャネル」として一般化し、`Promise.allSettled` で **LINE と MQTT を並列実行・待ち合わせ**るように変更しました。

### 背景（変更前の問題）
- MQTT 投稿は LINE 投稿の **成功後にのみ** 直列で fire-and-forget 実行されていた。
- LINE 投稿が失敗すると `AppError` を throw して抜けるため、**MQTT 投稿が一度も実行されなかった**。

### 変更後の挙動
- **LINE と MQTT を並列実行**し、両方の完了を待ち合わせる。
- **LINE が失敗しても MQTT を実行**する。
- 結果を集約して HTTP 応答を返す:
  - 全成功 → **200**
  - 一部成功 → **207 Multi-Status**（`{success:false, requestId, delivered, failed}` を JSON で返す）
  - 全失敗 → **502**（`LINE_PUSH_FAILED` を維持）

### HTTP セマンティクス / SendGrid 再送との整合
- 一部成功には **207 Multi-Status**（RFC 4918）を採用（複数操作の個別結果を表す正しいコード。`206` は Range 専用のため不採用）。
- **207・200 は 2xx** で SendGrid は成功扱い → 再送されず、非冪等な MQTT publish の二重送信は起きない。
- 再送が走るのは完全失敗（502）時のみ（MQTT も失敗しているため再試行は妥当）。

## 実装の要点
- 送信先を `{ name, run }` 記述子の配列にし、結果は配列順で名前にマッピング（位置依存を排除）。部分成功は `delivered>0 && failed>0` で判定（単一チャネルでは 207 にならない）。
- 全失敗時は明示的に `AppError(502)` を throw（`normalizeAppError` は生 Error を 500 化するため）。LINE 単独構成での失敗は従来どおり `LINE_PUSH_FAILED`。
- MQTT チャネルは `retries:1` ＋ 約500ms のデッドラインで応答ストール（→SendGrid タイムアウト→再送→LINE 二重送信）を防止。
- **mqtt-publish.js の堅牢化**: await 並列化で接続評価頻度が上がるため、`'error'` リスナー追加（未処理 error によるクラッシュ防止）、`connectTimeout:2000`/`reconnectPeriod:0`、`connect()` メモ化＋`close` 時の参照破棄（同時接続 race / dead client 残留の回避）。
- `mqttPublish` 判定は `!= null` にし `undefined` 渡し時のクラッシュを防止。

## 後方互換性
- `mqttPublish === null`（MQTT 未設定）時は LINE 単独チャネルとなり、成功→200 / 失敗→502 と従来どおり。207 は発生しない。
- ログイベント名（`line.push.*` / `mqtt.publish.*`）を維持。

## テスト
新規 [test/mail-webhook-delivery.test.js](test/mail-webhook-delivery.test.js) を追加（`package.json` の test 連結にも登録）:
1. LINE成功+MQTT成功 → 200
2. LINE成功+MQTT失敗 → 207（delivered/failed・Content-Type 検証）
3. LINE失敗+MQTT成功 → 207（**LINE失敗でも MQTT 実行**を検証）
4. 両失敗 → 502（`LINE_PUSH_FAILED`）
5-6. `mqttPublish:null` の 200 / 502 回帰ガード
7. MQTT リトライ
8. MQTT ハング → デッドラインで失敗チャネル化 → 207（ストールしない）

全テスト green（`pnpm test`）。既存テストも全て通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)