### PR TITLE
fix: MQTT publishデッドラインを3000msに引上げelapsedMsを記録

### DIFF
--- a/lib/mail-webhook.js
+++ b/lib/mail-webhook.js
@@ -17,7 +17,7 @@ const {
 } = require('./inbound-parse-webhook-signature');
 
 const mailWebhookMaxBytes = 30 * 1024 * 1024;
-const mqttPublishDeadlineMs = 500;
+const defaultMqttPublishDeadlineMs = 3000;
 const lineTextMessageMaxChars = 5000;
 const lineTextMessageTruncationMarker = '\r\n（省略）';
 const trackedMultipartFieldNames = new Set(['to', 'from', 'subject', 'charsets', 'text', 'html']);
@@ -244,6 +244,7 @@ const createMailWebhookHandler = ({
   logger,
   verifyInboundParseWebhookSignature = defaultVerifyInboundParseWebhookSignature,
   maxBytes = mailWebhookMaxBytes,
+  mqttPublishDeadlineMs = defaultMqttPublishDeadlineMs,
 }) => async (req, res, next) => {
   try {
     const {
@@ -398,6 +399,7 @@ const createMailWebhookHandler = ({
             requestId: req.requestId,
             topic: mqttPublish.topic,
           });
+          const startedAt = Date.now();
           await withDeadline(retryAsync({
             operation: () => mqttPublish.publish(mailContent.subject),
             retries: 1,
@@ -414,6 +416,8 @@ const createMailWebhookHandler = ({
           }), mqttPublishDeadlineMs).catch((error) => {
             logger.logError('mqtt.publish.failed', {
               requestId: req.requestId,
+              elapsedMs: Date.now() - startedAt,
+              deadlineMs: mqttPublishDeadlineMs,
               message: error && error.message,
             });
             throw error;
@@ -421,6 +425,7 @@ const createMailWebhookHandler = ({
           logger.logInfo('mqtt.publish.succeeded', {
             requestId: req.requestId,
             topic: mqttPublish.topic,
+            elapsedMs: Date.now() - startedAt,
           });
         },
       });

--- a/routes/webhook-routes.js
+++ b/routes/webhook-routes.js
@@ -20,6 +20,7 @@ const createWebhookRoutes = ({
   lineWebhookMiddleware,
   verifyInboundParseWebhookSignature,
   mailWebhookRateLimit,
+  mqttPublishDeadlineMs,
   logger,
 }) => {
   const router = express.Router();
@@ -57,6 +58,7 @@ const createWebhookRoutes = ({
       mqttPublish,
       logger,
       verifyInboundParseWebhookSignature,
+      mqttPublishDeadlineMs,
     }),
   );
 

--- a/test/mail-webhook-delivery.test.js
+++ b/test/mail-webhook-delivery.test.js
@@ -28,6 +28,7 @@ const createWebhookTestApp = ({
   logger,
   pushMessage = async () => ({}),
   mqttPublish = null,
+  mqttPublishDeadlineMs,
   verifyInboundParseWebhookSignature = () => {},
 } = {}) => {
   const app = express();
@@ -47,6 +48,7 @@ const createWebhookTestApp = ({
       pushMessage,
     },
     mqttPublish,
+    mqttPublishDeadlineMs,
     logger: resolvedLogger,
     verifyInboundParseWebhookSignature,
     mailWebhookRateLimit: {
@@ -107,6 +109,8 @@ const run = async () => {
     assert.strictEqual(published, 'private subject');
     assert.ok(events.includes('line.push.succeeded'));
     assert.ok(events.includes('mqtt.publish.succeeded'));
+    const succeededLog = logger.entries.find((entry) => entry.event === 'mqtt.publish.succeeded');
+    assert.strictEqual(typeof succeededLog.elapsedMs, 'number');
   }
 
   // 2. LINE ok + MQTT fail => 207
@@ -242,18 +246,24 @@ const run = async () => {
     assert.ok(events.includes('mqtt.publish.succeeded'));
   }
 
-  // 8. MQTT hangs => channel deadline fails it => 207 (no hang)
+  // 8. MQTT hangs => channel deadline fails it => 207 (no hang).
+  //    Inject a small deadline so the test stays fast.
   {
     const logger = createCaptureLogger();
     const { app } = createWebhookTestApp({
       logger,
       mqttPublish: { topic: 'test/topic', publish: () => new Promise(() => {}) },
+      mqttPublishDeadlineMs: 150,
     });
     const res = await postMailWebhook(app);
+    const failedLog = logger.entries.find((entry) => entry.event === 'mqtt.publish.failed');
 
     assert.strictEqual(res.status, 207);
     assert.deepStrictEqual(res.body.delivered, ['line']);
     assert.deepStrictEqual(res.body.failed, ['mqtt']);
+    assert.strictEqual(failedLog.message, 'MQTT publish deadline exceeded.');
+    assert.strictEqual(typeof failedLog.elapsedMs, 'number');
+    assert.strictEqual(failedLog.deadlineMs, 150);
   }
 
   console.log('mail webhook delivery tests passed');


### PR DESCRIPTION
## 概要
本番（fly.io `mail-to-linemsg-72411`, region `nrt`）で beebotte MQTT broker への publish が `MQTT publish deadline exceeded.` で失敗していた問題の修正。LINE は届くが MQTT が常に失敗して 207 になっていた。

## 根本原因
1. **`mqttPublishDeadlineMs`(500ms) < `connectTimeout`(2000ms)**。デッドラインが接続タイムアウトより短く、接続が500msを超えた時点で必ず先に発火（connectTimeout が事実上デッドコード化）。
2. **遠距離コールド接続**。`mqtt.beebotte.com` → `54.221.205.80`（AWS **us-east-1 / バージニア**）。`nrt`（東京）から長距離。実測でローカル→broker の TCP接続のみで ~480ms、MQTT は CONNECT/CONNACK の往復 + PUBLISH が上乗せ。
3. **コールド接続が頻発**。`min_machines_running=0` + `auto_stop_machines=true` でアイドル後はマシンがコールドスタートし MQTT シングルトンも新規。`reconnectPeriod:0`＋close時null化で切断後も毎回コールド接続。

→ 500ms では東京↔バージニアのコールド接続が間に合わず必ず失敗。

## 変更
- **[lib/mail-webhook.js](lib/mail-webhook.js)**: デッドライン既定を `500 → 3000ms`（`connectTimeout` と整合）。`createMailWebhookHandler` のオプション化（`mqttPublishDeadlineMs`、既定3000）。`mqtt.publish.succeeded` に `elapsedMs`、`mqtt.publish.failed` に `elapsedMs`/`deadlineMs` を追加（本番ログで実測・微調整できるように）。
- **[routes/webhook-routes.js](routes/webhook-routes.js)**: `mqttPublishDeadlineMs` を handler へ通す（テスト注入＋将来の env 連携用）。
- **[test/mail-webhook-delivery.test.js](test/mail-webhook-delivery.test.js)**: ハングテスト（ケース8）を `mqttPublishDeadlineMs: 150` 注入で高速化＋`elapsedMs`/`deadlineMs`/メッセージ検証。成功時の `elapsedMs` も検証。

## レビュー
- Codex adversarial review: **指摘なし**（passthrough・200/207/502ロジック退行なし・Date.nowはelapsedMs計測用で期限判定に影響なし）。
- `pnpm test` 全green（14スイート）。

## デプロイ後の確認
`fly logs -a mail-to-linemsg-72411` で `mqtt.publish.succeeded` の `elapsedMs` を確認 → コールド publish の実測値が 3000ms 未満（想定 400〜900ms）で deadline-exceeded が解消したか検証。常時2000ms超や失敗頻発なら beebotte のスロットリング/region 起因の可能性 → warm接続や mqtts(8883) を別途検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)