### PR TITLE
fix: MQTT publishをin-requestで再試行しない(retries:0)

### DIFF
--- a/lib/mail-webhook.js
+++ b/lib/mail-webhook.js
@@ -400,19 +400,13 @@ const createMailWebhookHandler = ({
             topic: mqttPublish.topic,
           });
           const startedAt = Date.now();
+          // コールド接続が高コスト（実測 ~860ms、遅延時はそれ以上）で、リトライは
+          // 2回目のフルなコールド接続を意味しデッドラインを食い潰すため再試行しない。
+          // 失敗は best-effort として扱う（LINE 成功なら 207、SendGrid 再送なし）。
           await withDeadline(retryAsync({
             operation: () => mqttPublish.publish(mailContent.subject),
-            retries: 1,
-            initialDelayMs: 100,
+            retries: 0,
             shouldRetry: shouldRetryMqttError,
-            onRetry: (error, attempt, delayMs) => {
-              logger.logWarn('mqtt.publish.retry', {
-                requestId: req.requestId,
-                attempt,
-                delayMs,
-                message: error && error.message,
-              });
-            },
           }), mqttPublishDeadlineMs).catch((error) => {
             logger.logError('mqtt.publish.failed', {
               requestId: req.requestId,

--- a/test/mail-webhook-delivery.test.js
+++ b/test/mail-webhook-delivery.test.js
@@ -221,7 +221,7 @@ const run = async () => {
     assert.strictEqual(res.body.error.code, 'LINE_PUSH_FAILED');
   }
 
-  // 7. MQTT retry: fail once then succeed => 200, mqtt.publish.retry logged
+  // 7. MQTT is not retried in-request: a single failure => 207, publish called once.
   {
     const logger = createCaptureLogger();
     let attempts = 0;
@@ -231,19 +231,17 @@ const run = async () => {
         topic: 'test/topic',
         publish: async () => {
           attempts += 1;
-          if (attempts === 1) {
-            throw new Error('transient');
-          }
+          throw new Error('transient');
         },
       },
     });
     const res = await postMailWebhook(app);
     const events = getEvents(logger);
 
-    assert.strictEqual(res.status, 200);
-    assert.strictEqual(attempts, 2);
-    assert.ok(events.includes('mqtt.publish.retry'));
-    assert.ok(events.includes('mqtt.publish.succeeded'));
+    assert.strictEqual(res.status, 207);
+    assert.strictEqual(attempts, 1);
+    assert.ok(!events.includes('mqtt.publish.retry'));
+    assert.ok(events.includes('mqtt.publish.failed'));
   }
 
   // 8. MQTT hangs => channel deadline fails it => 207 (no hang).


### PR DESCRIPTION
## 概要
deadline を 3000ms に上げた後も本番（fly `mail-to-linemsg-72411`, nrt）で `MQTT publish deadline exceeded.` が再発していた問題の修正。MQTT チャネルの in-request リトライを廃止（`retries:0`）。

## 根本原因（systematic-debugging / fly logs 実測）
追加済みの `elapsedMs` 計装で取得:

| event | elapsedMs | 状況 |
|---|---|---|
| succeeded | 858 | コールド接続（標準） |
| succeeded | 4 | warm |
| succeeded | 869 | コールド接続（標準） |
| **failed** | **3120**（deadline 3000） | コールド接続で超過 |

標準コールド接続は ~860ms で 3000ms に収まる。失敗は 3120ms ≒ deadline 張り付き。
`retries:1` + `connectTimeout:2000` + `reconnectPeriod:0`（close時 client 破棄）の構成では、**初回の遅い/失敗コールド接続（~2000ms）→ close → 100ms 待ち → 2回目の新規コールド接続 → 3000ms で打ち切り**。**retry が増幅器**になり、リトライ＝2回目のフルなコールド接続が deadline を食い潰していた。

## 変更
- [lib/mail-webhook.js](lib/mail-webhook.js): MQTT チャネルの `retryAsync` を `retries:1` → **`retries:0`**。到達不能になった `initialDelayMs`・`onRetry`（`mqtt.publish.retry` ログ）を削除。意図コメント追加。単発接続は connectTimeout 2000ms 上限 + publish ≈ 最大~2.1s で deadline 3000ms 以内。失敗は best-effort（LINE 成功なら 207、SendGrid 再送なし）。
- [test/mail-webhook-delivery.test.js](test/mail-webhook-delivery.test.js): 旧「リトライ成功」ケースを **「リトライしない」検証**（単発失敗→207、`publish` 1回のみ、`mqtt.publish.retry` 不在）に置換。

`mqtt-publish.js` と deadline 値（3000ms）は変更なし。

## レビュー
- Codex adversarial review: **指摘なし**（retries:0 で単発実行+失敗時 rethrow、`shouldRetryMqttError` 参照維持、200/207/502 ロジック退行なし、テスト整合）。
- `pnpm test` 全 green（14スイート）。

## デプロイ後の確認
`fly logs -a mail-to-linemsg-72411` で `mqtt.publish.succeeded` の `elapsedMs` が単発接続帯（~860ms、遅延時も ~2s 程度）に収まり、deadline 超過（3000ms 張り付き）が消えることを確認。

## 別件（要観察・本PR対象外）
ログの大半が `failed:["line"]`（本番で LINE push 失敗・MQTT のみ成功で 207）。MQTT deadline とは別問題で、LINE 側の失敗要因は別途調査が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)