### PR TITLE
chore: dependabot で c8 のメジャー更新を ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    ignore:
+      # minimatch を 3.1.4 に固定しているため c8 は ^9 系に結合している
+      # (c8@10+ は minimatch@9+ を要求し test-exclude の named import と衝突する)
+      - dependency-name: "c8"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
## 背景

dependabot の PR #83 (c8 9.1.0 → 11.0.0) の CI test ジョブが `TypeError: minimatch is not a function` で失敗していた。

## 根本原因

- c8@11 は `test-exclude@8.0.0` を引き込み、これは minimatch を named export で読み込む (`const { minimatch } = require('minimatch')`、`minimatch@^10` を要求)。
- 本リポジトリは `pnpm-workspace.yaml` でグローバル override `"minimatch": "3.1.4"` を設定しており (brace-expansion ReDoS 対策 GHSA-f886-m6hf-6m8v に伴うサプライチェーン固定)、test-exclude@8 のツリーにも 3.1.4 が注入される。
- minimatch@3.1.4 の `module.exports` は関数本体で `.minimatch` プロパティを持たないため `{ minimatch }` が undefined になり落ちる。
- `pnpm-workspace.yaml` のコメントどおり c8 は ^9 系に固定する設計。

## 対応

- c8@11 の利点 (CVE-2026-26996 対応の新 minimatch) は、固定中の 3.1.4 が脆弱範囲 `< 3.1.3` 非該当で既に安全なため不要。c8 は dev 専用。
- PR #83 はクローズ済み。dependabot が c8 メジャーを再提案しないよう npm ecosystem に ignore を追加した。

## 検証

- `pnpm run coverage` が c8@9.1.0 で従来どおり全件 pass・lcov 出力されることを確認 (回帰なし)。
- `.github/dependabot.yml` の YAML 構文を検証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)