### PR TITLE
test: routes/page-routes.js・webhook-routes.js のテストを追加しカバレッジを拡充

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "node test/logger.test.js && node test/decode-transfer-encoding.test.js && node test/mail-text.test.js && node test/e2e-mail-samples.test.js && node test/csrf-protection.test.js && node test/session-security.test.js && node test/address-ownership.test.js && node test/inbound-parse-webhook-signature.test.js && node test/errors.test.js && node test/app-wiring.test.js && node test/codeql-fixes.test.js && node test/mail-webhook-rate-limit.test.js && node test/mail-webhook-observability.test.js && node test/mail-webhook-delivery.test.js && node test/api-routes.test.js",
+    "test": "node scripts/run-tests.js",
     "coverage": "c8 pnpm test",
     "qdrant:diff-targets": "node scripts/qdrant-diff-targets.js",
     "qdrant:store-batch": "node scripts/qdrant-store-batch.js",

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,0 +1,36 @@
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const testDir = path.join(__dirname, '..', 'test');
+
+const testFiles = fs
+  .readdirSync(testDir)
+  .filter((name) => name.endsWith('.test.js'))
+  .sort();
+
+if (testFiles.length === 0) {
+  console.error('[run-tests] no test files found in test/');
+  process.exit(1);
+}
+
+for (const name of testFiles) {
+  const filePath = path.join(testDir, name);
+  const result = spawnSync(process.execPath, [filePath], { stdio: 'inherit' });
+
+  if (result.error) {
+    console.error(`[run-tests] failed to run ${name}:`, result.error);
+    process.exit(1);
+  }
+
+  if (result.signal) {
+    console.error(`[run-tests] ${name} terminated by signal ${result.signal}`);
+    process.exit(1);
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status);
+  }
+}
+
+process.exit(0);

--- a/test/api-routes.test.js
+++ b/test/api-routes.test.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const express = require('express');
 const bodyParser = require('body-parser');
 const session = require('express-session');
 const cookieParser = require('cookie-parser');
@@ -7,12 +6,13 @@ const { doubleCsrf } = require('csrf-csrf');
 const request = require('supertest');
 const { createApiRoutes } = require('../routes/api-routes');
 const { AppError, createErrorMiddleware } = require('../lib/errors');
+const { createBaseApp } = require('./helpers/route-test-app');
 
 // 各ケースで fresh な app と db/helpers スタブを生成する（ケース間汚染を防ぐ）。
 // createApp は cookie.secure=true を強制し supertest(HTTP) では cookie が届かないため、
 // スタンドアロンの express アプリに createApiRoutes を直接マウントする。
 const createTestApp = (overrides = {}) => {
-  const app = express();
+  const app = createBaseApp();
   const csrf = doubleCsrf({
     getSecret: () => 'csrf-test-secret',
     getSessionIdentifier: (req) => req.sessionID || '',
@@ -50,10 +50,6 @@ const createTestApp = (overrides = {}) => {
   app.use(cookieParser('test-secret'));
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use(bodyParser.json());
-  app.use((req, res, next) => {
-    req.requestId = 'test-request-id';
-    next();
-  });
   app.use(createApiRoutes({
     db,
     helpers,

--- a/test/helpers/route-test-app.js
+++ b/test/helpers/route-test-app.js
@@ -1,0 +1,62 @@
+const express = require('express');
+
+// logInfo/logWarn/logError の呼び出しを calls 配列にキャプチャするロガースタブ。
+const createTestLogger = () => {
+  const calls = [];
+  const capture = (level) => (event, payload) => {
+    calls.push({ level, event, payload });
+  };
+
+  return {
+    calls,
+    logInfo: capture('info'),
+    logWarn: capture('warn'),
+    logError: capture('error'),
+    createLogCorrelationId: (value) => (value ? `test-correlation-${value}` : undefined),
+  };
+};
+
+// req.requestId を付与するミドルウェアまで載せた express アプリを返す。
+const createBaseApp = ({ requestId = 'test-request-id' } = {}) => {
+  const app = express();
+  app.use((req, res, next) => {
+    req.requestId = requestId;
+    next();
+  });
+  return app;
+};
+
+// req.session の代わりに渡せるフェイクセッション。regenerate/destroy はスパイとして呼び出し回数を記録する。
+const createFakeSession = (initial = {}) => {
+  const session = {
+    ...initial,
+    regenerateCalls: 0,
+    destroyCalls: 0,
+    regenerate(cb) {
+      session.regenerateCalls += 1;
+      cb();
+    },
+    destroy() {
+      session.destroyCalls += 1;
+    },
+  };
+  return session;
+};
+
+// global.fetch を stub に差し替えて fn を実行し、finally で必ず元に戻す。
+const withStubbedFetch = async (stub, fn) => {
+  const original = global.fetch;
+  global.fetch = stub;
+  try {
+    return await fn();
+  } finally {
+    global.fetch = original;
+  }
+};
+
+module.exports = {
+  createTestLogger,
+  createBaseApp,
+  createFakeSession,
+  withStubbedFetch,
+};

--- a/test/page-routes.test.js
+++ b/test/page-routes.test.js
@@ -1,0 +1,462 @@
+const assert = require('assert');
+const path = require('path');
+const request = require('supertest');
+const { createErrorMiddleware } = require('../lib/errors');
+const { createPageRoutes } = require('../routes/page-routes');
+const {
+  createTestLogger,
+  createBaseApp,
+  createFakeSession,
+  withStubbedFetch,
+} = require('./helpers/route-test-app');
+
+const rootDir = path.join(__dirname, '..');
+
+const defaultLineLoginConfig = {
+  channelId: 'login-channel',
+  channelSecret: 'login-secret',
+  callbackUrl: 'http://example.test/callback',
+};
+
+// createLogCorrelationId を持たないロガー（L76-80 の undefined 分岐を確認するため）。
+const createBarebonesLogger = () => {
+  const calls = [];
+  return {
+    calls,
+    logInfo: (event, payload) => calls.push({ level: 'info', event, payload }),
+    logWarn: (event, payload) => calls.push({ level: 'warn', event, payload }),
+    logError: (event, payload) => calls.push({ level: 'error', event, payload }),
+  };
+};
+
+// createRequestId のスタブ。呼び出しごとに異なる値を返す（state と nonce を区別するため）。
+const createSequentialRequestId = () => {
+  let n = 0;
+  return () => {
+    n += 1;
+    return `req-id-${n}`;
+  };
+};
+
+const okResponse = (payload) => ({ ok: true, status: 200, json: async () => payload });
+const errorResponse = (status, payload = {}) => ({ ok: false, status, json: async () => payload });
+
+// LINE API (token/verify) 向けの fetch スタブ。呼び出し履歴 (url, options) を calls に記録する。
+const createLineFetchStub = ({ tokenResponse = okResponse({}), verifyResponse = okResponse({}) } = {}) => {
+  const calls = [];
+  const stub = async (url, options) => {
+    calls.push({ url, options });
+    if (String(url).includes('oauth2/v2.1/token')) {
+      return tokenResponse;
+    }
+    if (String(url).includes('oauth2/v2.1/verify')) {
+      return verifyResponse;
+    }
+    throw new Error(`unexpected fetch url: ${url}`);
+  };
+  stub.calls = calls;
+  return stub;
+};
+
+// ケースごとに fresh な app を作る。view engine / fake session / createPageRoutes / error middleware をまとめて載せる。
+const createTestApp = ({
+  db: dbOverrides = {},
+  msgbot: msgbotOverrides = {},
+  helpers: helpersOverrides = {},
+  lineLoginConfig = defaultLineLoginConfig,
+  logger = createTestLogger(),
+  createRequestId = createSequentialRequestId(),
+  session: sessionOverrides = {},
+} = {}) => {
+  const app = createBaseApp();
+  app.set('view engine', 'ejs');
+
+  const session = createFakeSession(sessionOverrides);
+  app.use((req, res, next) => {
+    req.session = session;
+    next();
+  });
+
+  const db = {
+    getRegisteredAddrByExtUserId: async () => ({}),
+    addUser: async () => ({ ext_user_id: 'default-ext-user-id' }),
+    addRecipient: async () => {},
+    ...dbOverrides,
+  };
+  const msgbot = {
+    getProfile: async () => ({ displayName: 'self' }),
+    ...msgbotOverrides,
+  };
+  const helpers = {
+    isLoggedIn: async () => false,
+    ...helpersOverrides,
+  };
+
+  app.use(createPageRoutes({
+    rootDir,
+    db,
+    msgbot,
+    lineLoginConfig,
+    helpers,
+    logger,
+    createRequestId,
+    authRateLimit: { windowMs: 60000, limit: 1000 },
+  }));
+  app.use(createErrorMiddleware());
+
+  return { app, db, msgbot, helpers, logger, session };
+};
+
+// /callback 失敗系の共通アサーション: 302 login_failed + session.destroy + auth.callback.failed ログ。
+const assertCallbackFailed = (res, session, logger) => {
+  assert.strictEqual(res.status, 302);
+  assert.strictEqual(res.headers.location, '/login?reason=login_failed');
+  assert.strictEqual(session.destroyCalls, 1);
+  assert.ok(logger.calls.some((c) => c.event === 'auth.callback.failed'));
+};
+
+const run = async () => {
+  // ---- GET / ----
+  {
+    // 1. 未ログイン → 302、Location は /login
+    const { app } = createTestApp({
+      helpers: { isLoggedIn: async () => false },
+    });
+    const res = await request(app).get('/');
+
+    assert.strictEqual(res.status, 302);
+    assert.strictEqual(res.headers.location, '/login');
+  }
+  {
+    // 2. ログイン済み → 200、getRegisteredAddrByExtUserId が session の userId で呼ばれる
+    let getRegisteredAddrArgs = null;
+    const { app } = createTestApp({
+      session: { userId: 'ext-user-id' },
+      helpers: { isLoggedIn: async () => true },
+      db: {
+        getRegisteredAddrByExtUserId: async (...args) => {
+          getRegisteredAddrArgs = args;
+          return {};
+        },
+      },
+    });
+    const res = await request(app).get('/');
+
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(getRegisteredAddrArgs, ['ext-user-id']);
+  }
+
+  {
+    // 2b. getRegisteredAddrByExtUserId が reject した場合、next(error) 経由でエラーミドルウェアに渡り 500 になる
+    const { app } = createTestApp({
+      session: { userId: 'ext-user-id' },
+      helpers: { isLoggedIn: async () => true },
+      db: {
+        getRegisteredAddrByExtUserId: async () => { throw new Error('db error'); },
+      },
+    });
+    const res = await request(app).get('/');
+
+    assert.strictEqual(res.status, 500);
+  }
+
+  // ---- GET /login ----
+  {
+    // 3. ログイン済み → 302、Location は /
+    const { app } = createTestApp({
+      helpers: { isLoggedIn: async () => true },
+    });
+    const res = await request(app).get('/login');
+
+    assert.strictEqual(res.status, 302);
+    assert.strictEqual(res.headers.location, '/');
+  }
+  {
+    // 4. 未ログイン → 200
+    const { app } = createTestApp({
+      helpers: { isLoggedIn: async () => false },
+    });
+    const res = await request(app).get('/login');
+
+    assert.strictEqual(res.status, 200);
+  }
+
+  // ---- GET /logout ----
+  {
+    // 5. session.destroy が呼ばれ、302 Location /login?reason=logged_out
+    const { app, session } = createTestApp();
+    const res = await request(app).get('/logout');
+
+    assert.strictEqual(res.status, 302);
+    assert.strictEqual(res.headers.location, '/login?reason=logged_out');
+    assert.strictEqual(session.destroyCalls, 1);
+  }
+
+  // ---- GET /auth ----
+  {
+    // 6. 設定不備（channelId欠落 / channelSecret欠落 / callbackUrl欠落）→ 500 JSON + auth.config.invalid ログ
+    const invalidConfigs = [
+      { channelSecret: 'login-secret', callbackUrl: 'http://example.test/callback' },
+      { channelId: 'login-channel', callbackUrl: 'http://example.test/callback' },
+      { channelId: 'login-channel', channelSecret: 'login-secret' },
+    ];
+    for (const lineLoginConfig of invalidConfigs) {
+      const { app, logger } = createTestApp({ lineLoginConfig });
+      const res = await request(app).get('/auth');
+
+      assert.strictEqual(res.status, 500);
+      assert.deepStrictEqual(res.body, { msg: 'LINE login configuration is invalid.' });
+      assert.ok(logger.calls.some((c) => c.event === 'auth.config.invalid'));
+    }
+  }
+  {
+    // 7. 正常 → 302、authorize URL のクエリと session に保存された state/nonce が一致
+    const { app, session } = createTestApp();
+    const res = await request(app).get('/auth');
+
+    assert.strictEqual(res.status, 302);
+    const { location } = res.headers;
+    assert.ok(location.startsWith('https://access.line.me/oauth2/v2.1/authorize?'));
+    const url = new URL(location);
+    assert.strictEqual(url.searchParams.get('response_type'), 'code');
+    assert.strictEqual(url.searchParams.get('client_id'), 'login-channel');
+    assert.strictEqual(url.searchParams.get('redirect_uri'), 'http://example.test/callback');
+    assert.strictEqual(url.searchParams.get('scope'), 'profile openid');
+    assert.strictEqual(url.searchParams.get('state'), session.line_login_state);
+    assert.strictEqual(url.searchParams.get('nonce'), session.line_login_nonce);
+    assert.notStrictEqual(url.searchParams.get('state'), url.searchParams.get('nonce'));
+  }
+
+  // ---- GET /callback 失敗系 ----
+  {
+    // 8. code欠落（state のみ）→ fetch は呼ばれない
+    const fetchStub = createLineFetchStub();
+    await withStubbedFetch(fetchStub, async () => {
+      const { app, session, logger } = createTestApp({
+        session: { line_login_state: 'state-1' },
+      });
+      const res = await request(app).get('/callback').query({ state: 'state-1' });
+
+      assertCallbackFailed(res, session, logger);
+      assert.strictEqual(fetchStub.calls.length, 0);
+    });
+  }
+  {
+    // 9. state欠落（code のみ）→ fetch は呼ばれない
+    const fetchStub = createLineFetchStub();
+    await withStubbedFetch(fetchStub, async () => {
+      const { app, session, logger } = createTestApp({
+        session: { line_login_state: 'state-1' },
+      });
+      const res = await request(app).get('/callback').query({ code: 'code-1' });
+
+      assertCallbackFailed(res, session, logger);
+      assert.strictEqual(fetchStub.calls.length, 0);
+    });
+  }
+  {
+    // 10. state不一致 → fetch は呼ばれない
+    const fetchStub = createLineFetchStub();
+    await withStubbedFetch(fetchStub, async () => {
+      const { app, session, logger } = createTestApp({
+        session: { line_login_state: 'state-1' },
+      });
+      const res = await request(app).get('/callback').query({ code: 'code-1', state: 'other-state' });
+
+      assertCallbackFailed(res, session, logger);
+      assert.strictEqual(fetchStub.calls.length, 0);
+    });
+  }
+  {
+    // 11. token API が non-ok → verify は呼ばれない
+    const fetchStub = createLineFetchStub({
+      tokenResponse: errorResponse(400, { error_description: 'invalid code' }),
+    });
+    await withStubbedFetch(fetchStub, async () => {
+      const { app, session, logger } = createTestApp({
+        session: { line_login_state: 'state-1' },
+      });
+      const res = await request(app).get('/callback').query({ code: 'code-1', state: 'state-1' });
+
+      assertCallbackFailed(res, session, logger);
+      assert.strictEqual(fetchStub.calls.length, 1);
+    });
+  }
+  {
+    // 12a. token応答不正: expires_in が 0（id_token あり）
+    const fetchStub = createLineFetchStub({
+      tokenResponse: okResponse({ expires_in: 0, id_token: 'idtoken' }),
+    });
+    await withStubbedFetch(fetchStub, async () => {
+      const { app, session, logger } = createTestApp({
+        session: { line_login_state: 'state-1' },
+      });
+      const res = await request(app).get('/callback').query({ code: 'code-1', state: 'state-1' });
+
+      assertCallbackFailed(res, session, logger);
+      assert.strictEqual(fetchStub.calls.length, 1);
+    });
+  }
+  {
+    // 12b. token応答不正: id_token 欠落（expires_in > 0）
+    const fetchStub = createLineFetchStub({
+      tokenResponse: okResponse({ expires_in: 3600 }),
+    });
+    await withStubbedFetch(fetchStub, async () => {
+      const { app, session, logger } = createTestApp({
+        session: { line_login_state: 'state-1' },
+      });
+      const res = await request(app).get('/callback').query({ code: 'code-1', state: 'state-1' });
+
+      assertCallbackFailed(res, session, logger);
+      assert.strictEqual(fetchStub.calls.length, 1);
+    });
+  }
+  {
+    // 13. verify 応答で sub 欠落
+    const fetchStub = createLineFetchStub({
+      tokenResponse: okResponse({ expires_in: 3600, id_token: 'idtoken' }),
+      verifyResponse: okResponse({ nonce: 'nonce-1' }),
+    });
+    await withStubbedFetch(fetchStub, async () => {
+      const { app, session, logger } = createTestApp({
+        session: { line_login_state: 'state-1', line_login_nonce: 'nonce-1' },
+      });
+      const res = await request(app).get('/callback').query({ code: 'code-1', state: 'state-1' });
+
+      assertCallbackFailed(res, session, logger);
+      assert.strictEqual(fetchStub.calls.length, 2);
+    });
+  }
+  {
+    // 14. verify 応答で nonce 不一致
+    const fetchStub = createLineFetchStub({
+      tokenResponse: okResponse({ expires_in: 3600, id_token: 'idtoken' }),
+      verifyResponse: okResponse({ sub: 'U123', nonce: 'wrong-nonce' }),
+    });
+    await withStubbedFetch(fetchStub, async () => {
+      const { app, session, logger } = createTestApp({
+        session: { line_login_state: 'state-1', line_login_nonce: 'nonce-1' },
+      });
+      const res = await request(app).get('/callback').query({ code: 'code-1', state: 'state-1' });
+
+      assertCallbackFailed(res, session, logger);
+      assert.strictEqual(fetchStub.calls.length, 2);
+    });
+  }
+
+  // ---- GET /callback 成功系 ----
+  {
+    // 15. 成功: addUser/addRecipient/regenerate/session クリア/リダイレクト/token リクエスト body を検証
+    const fetchStub = createLineFetchStub({
+      tokenResponse: okResponse({ expires_in: 3600, id_token: 'idtoken' }),
+      verifyResponse: okResponse({ sub: 'U123', nonce: 'nonce-1' }),
+    });
+    let addUserArgs = null;
+    let addRecipientArgs = null;
+    await withStubbedFetch(fetchStub, async () => {
+      const { app, session } = createTestApp({
+        session: { line_login_state: 'state-1', line_login_nonce: 'nonce-1' },
+        db: {
+          addUser: async (...args) => {
+            addUserArgs = args;
+            return { ext_user_id: 'ext-1' };
+          },
+          addRecipient: async (...args) => { addRecipientArgs = args; },
+        },
+        msgbot: {
+          getProfile: async () => ({ displayName: 'テストユーザー' }),
+        },
+      });
+      const res = await request(app).get('/callback').query({ code: 'code-1', state: 'state-1' });
+
+      assert.strictEqual(res.status, 302);
+      assert.strictEqual(res.headers.location, '/');
+      assert.deepStrictEqual(addUserArgs, ['U123']);
+      assert.deepStrictEqual(addRecipientArgs, ['U123', 0, 'テストユーザー', 'ext-1']);
+      assert.strictEqual(session.regenerateCalls, 1);
+      assert.strictEqual(session.userId, 'ext-1');
+      assert.strictEqual('line_login_state' in session, false);
+      assert.strictEqual('line_login_nonce' in session, false);
+
+      const tokenCall = fetchStub.calls.find((c) => String(c.url).includes('oauth2/v2.1/token'));
+      assert.ok(tokenCall);
+      assert.strictEqual(tokenCall.options.body.get('grant_type'), 'authorization_code');
+      assert.strictEqual(tokenCall.options.body.get('client_secret'), 'login-secret');
+    });
+  }
+  {
+    // 16. msgbot.getProfile が reject → displayName フォールバック 'self' で addRecipient
+    const fetchStub = createLineFetchStub({
+      tokenResponse: okResponse({ expires_in: 3600, id_token: 'idtoken' }),
+      verifyResponse: okResponse({ sub: 'U123', nonce: 'nonce-1' }),
+    });
+    let addRecipientArgs = null;
+    await withStubbedFetch(fetchStub, async () => {
+      const { app } = createTestApp({
+        session: { line_login_state: 'state-1', line_login_nonce: 'nonce-1' },
+        db: {
+          addUser: async () => ({ ext_user_id: 'ext-1' }),
+          addRecipient: async (...args) => { addRecipientArgs = args; },
+        },
+        msgbot: {
+          getProfile: async () => { throw new Error('profile api down'); },
+        },
+      });
+      const res = await request(app).get('/callback').query({ code: 'code-1', state: 'state-1' });
+
+      assert.strictEqual(res.status, 302);
+      assert.deepStrictEqual(addRecipientArgs, ['U123', 0, 'self', 'ext-1']);
+    });
+  }
+  {
+    // 17. displayName が64文字以上 → addRecipient の第3引数は先頭63文字
+    const longDisplayName = 'あ'.repeat(70);
+    const fetchStub = createLineFetchStub({
+      tokenResponse: okResponse({ expires_in: 3600, id_token: 'idtoken' }),
+      verifyResponse: okResponse({ sub: 'U123', nonce: 'nonce-1' }),
+    });
+    let addRecipientArgs = null;
+    await withStubbedFetch(fetchStub, async () => {
+      const { app } = createTestApp({
+        session: { line_login_state: 'state-1', line_login_nonce: 'nonce-1' },
+        db: {
+          addUser: async () => ({ ext_user_id: 'ext-1' }),
+          addRecipient: async (...args) => { addRecipientArgs = args; },
+        },
+        msgbot: {
+          getProfile: async () => ({ displayName: longDisplayName }),
+        },
+      });
+      const res = await request(app).get('/callback').query({ code: 'code-1', state: 'state-1' });
+
+      assert.strictEqual(res.status, 302);
+      assert.strictEqual(addRecipientArgs[2], longDisplayName.substring(0, 63));
+      assert.strictEqual(addRecipientArgs[2].length, 63);
+    });
+  }
+
+  // ---- logger 分岐 ----
+  {
+    // 18. logger が createLogCorrelationId を持たない（logInfo/logWarn/logError のみ）でも GET / が落ちない
+    const barebonesLogger = createBarebonesLogger();
+    const { app } = createTestApp({
+      session: { userId: 'ext-user-id' },
+      helpers: { isLoggedIn: async () => true },
+      logger: barebonesLogger,
+    });
+    const res = await request(app).get('/');
+
+    assert.strictEqual(res.status, 200);
+    const renderCall = barebonesLogger.calls.find((c) => c.event === 'page.index.render');
+    assert.ok(renderCall);
+    assert.strictEqual(renderCall.payload.extUserKey, undefined);
+  }
+
+  console.log('page-routes tests passed');
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/test/page-routes.test.js
+++ b/test/page-routes.test.js
@@ -283,6 +283,36 @@ const run = async () => {
     });
   }
   {
+    // 11b. token API が non-ok（error_description なし）→ json.error フォールバック
+    const fetchStub = createLineFetchStub({
+      tokenResponse: errorResponse(400, { error: 'invalid_request' }),
+    });
+    await withStubbedFetch(fetchStub, async () => {
+      const { app, session, logger } = createTestApp({
+        session: { line_login_state: 'state-1' },
+      });
+      const res = await request(app).get('/callback').query({ code: 'code-1', state: 'state-1' });
+
+      assertCallbackFailed(res, session, logger);
+      assert.strictEqual(fetchStub.calls.length, 1);
+    });
+  }
+  {
+    // 11c. token API が non-ok（エラー情報なし）→ ステータス文言フォールバック
+    const fetchStub = createLineFetchStub({
+      tokenResponse: errorResponse(400, {}),
+    });
+    await withStubbedFetch(fetchStub, async () => {
+      const { app, session, logger } = createTestApp({
+        session: { line_login_state: 'state-1' },
+      });
+      const res = await request(app).get('/callback').query({ code: 'code-1', state: 'state-1' });
+
+      assertCallbackFailed(res, session, logger);
+      assert.strictEqual(fetchStub.calls.length, 1);
+    });
+  }
+  {
     // 12a. token応答不正: expires_in が 0（id_token あり）
     const fetchStub = createLineFetchStub({
       tokenResponse: okResponse({ expires_in: 0, id_token: 'idtoken' }),

--- a/test/webhook-routes.test.js
+++ b/test/webhook-routes.test.js
@@ -1,0 +1,181 @@
+const assert = require('assert');
+const request = require('supertest');
+const { createErrorMiddleware } = require('../lib/errors');
+const { createWebhookRoutes } = require('../routes/webhook-routes');
+const { createTestLogger, createBaseApp } = require('./helpers/route-test-app');
+
+// POST /msg-webhook 用の fresh app を作る。db/msgbot はケースごとにスタブを差し替え可能。
+// mqttPublish / verifyInboundParseWebhookSignature / mailWebhookRateLimit / mqttPublishDeadlineMs は
+// /mail-webhook 側の依存で /msg-webhook には無関係だが、createWebhookRoutes の生成には必要なため
+// 最小のダミーを渡す（mail-webhook-delivery.test.js を参考）。
+const createTestApp = ({
+  events = [],
+  db: dbOverrides = {},
+  msgbot: msgbotOverrides = {},
+  logger = createTestLogger(),
+} = {}) => {
+  const app = createBaseApp();
+  const db = {
+    addRecipient: async () => {},
+    ...dbOverrides,
+  };
+  const msgbot = {
+    getGroupSummary: async () => ({ groupName: 'dummy' }),
+    ...msgbotOverrides,
+  };
+  app.use(createWebhookRoutes({
+    db,
+    msgbot,
+    mqttPublish: null,
+    lineWebhookMiddleware: (req, res, next) => {
+      req.body = { events };
+      next();
+    },
+    verifyInboundParseWebhookSignature: () => {},
+    mailWebhookRateLimit: undefined,
+    mqttPublishDeadlineMs: undefined,
+    logger,
+  }));
+  app.use(createErrorMiddleware());
+
+  return { app, db, msgbot, logger };
+};
+
+const run = async () => {
+  // 1. join + group 成功: getGroupSummary / addRecipient が正しい引数で呼ばれる
+  {
+    let getGroupSummaryArgs = null;
+    let addRecipientArgs = null;
+    const { app } = createTestApp({
+      events: [{ type: 'join', source: { type: 'group', groupId: 'G1' } }],
+      msgbot: {
+        getGroupSummary: async (...args) => {
+          getGroupSummaryArgs = args;
+          return { groupName: 'テストグループ' };
+        },
+      },
+      db: {
+        addRecipient: async (...args) => { addRecipientArgs = args; },
+      },
+    });
+    const res = await request(app).post('/msg-webhook').send({});
+
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(getGroupSummaryArgs, ['G1']);
+    assert.deepStrictEqual(addRecipientArgs, ['G1', 1, 'テストグループ']);
+  }
+
+  // 2. groupName が64文字以上の場合、addRecipient には先頭63文字に切詰められた値が渡る
+  {
+    const longGroupName = 'x'.repeat(70);
+    let addRecipientArgs = null;
+    const { app } = createTestApp({
+      events: [{ type: 'join', source: { type: 'group', groupId: 'G1' } }],
+      msgbot: {
+        getGroupSummary: async () => ({ groupName: longGroupName }),
+      },
+      db: {
+        addRecipient: async (...args) => { addRecipientArgs = args; },
+      },
+    });
+    const res = await request(app).post('/msg-webhook').send({});
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(addRecipientArgs[2], longGroupName.substring(0, 63));
+    assert.strictEqual(addRecipientArgs[2].length, 63);
+  }
+
+  // 3. join 以外のイベントでは getGroupSummary / addRecipient とも未呼び出し
+  {
+    let getGroupSummaryCalls = 0;
+    let addRecipientCalls = 0;
+    const { app } = createTestApp({
+      events: [{ type: 'message', source: { type: 'user' } }],
+      msgbot: {
+        getGroupSummary: async () => { getGroupSummaryCalls += 1; return { groupName: 'x' }; },
+      },
+      db: {
+        addRecipient: async () => { addRecipientCalls += 1; },
+      },
+    });
+    const res = await request(app).post('/msg-webhook').send({});
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(getGroupSummaryCalls, 0);
+    assert.strictEqual(addRecipientCalls, 0);
+  }
+
+  // 4. join だが source.type が group でない場合も未呼び出し（分岐網羅）
+  {
+    let getGroupSummaryCalls = 0;
+    let addRecipientCalls = 0;
+    const { app } = createTestApp({
+      events: [{ type: 'join', source: { type: 'room' } }],
+      msgbot: {
+        getGroupSummary: async () => { getGroupSummaryCalls += 1; return { groupName: 'x' }; },
+      },
+      db: {
+        addRecipient: async () => { addRecipientCalls += 1; },
+      },
+    });
+    const res = await request(app).post('/msg-webhook').send({});
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(getGroupSummaryCalls, 0);
+    assert.strictEqual(addRecipientCalls, 0);
+  }
+
+  // 5. events が空配列（event が undefined になる分岐）
+  {
+    const { app } = createTestApp({ events: [] });
+    const res = await request(app).post('/msg-webhook').send({});
+
+    assert.strictEqual(res.status, 200);
+  }
+
+  // 6. getGroupSummary が reject した場合、error middleware 経由で 500 の JSON エラーになる
+  {
+    const { app } = createTestApp({
+      events: [{ type: 'join', source: { type: 'group', groupId: 'G1' } }],
+      msgbot: {
+        getGroupSummary: async () => { throw new Error('line api down'); },
+      },
+    });
+    const res = await request(app).post('/msg-webhook').send({});
+
+    assert.strictEqual(res.status, 500);
+    assert.match(res.headers['content-type'], /application\/json/);
+    assert.strictEqual(res.body.error.code, 'INTERNAL_ERROR');
+  }
+
+  // 7. logger に createLogCorrelationId が無い場合でも join 処理が落ちず 200 を返す（createSafeLogId の undefined 分岐）
+  {
+    let addRecipientArgs = null;
+    const barebonesLogger = {
+      logInfo() {},
+      logWarn() {},
+      logError() {},
+    };
+    const { app } = createTestApp({
+      events: [{ type: 'join', source: { type: 'group', groupId: 'G1' } }],
+      logger: barebonesLogger,
+      msgbot: {
+        getGroupSummary: async () => ({ groupName: 'テストグループ' }),
+      },
+      db: {
+        addRecipient: async (...args) => { addRecipientArgs = args; },
+      },
+    });
+    const res = await request(app).post('/msg-webhook').send({});
+
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(addRecipientArgs, ['G1', 1, 'テストグループ']);
+  }
+
+  console.log('webhook-routes tests passed');
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## 概要

PR #88（api-routes.js のテスト拡充）の続きとして、残る低カバレッジ2ファイルのテストを拡充する。

| ファイル | Before (Stmts/Branch) | After (Stmts/Branch) |
|---|---|---|
| routes/page-routes.js | 64.04% / 40% | **100% / 100%** |
| routes/webhook-routes.js | 72.85% / 100% | **100% / 100%** |
| 全体 | 87.65% | **93.16%** |

未カバーだった実体は LINE OAuth ログインフロー（state/nonce 検証・セッション再生成）と /msg-webhook の group join 処理で、dependabot 更新の回帰検出網として価値が高い箇所。

## 変更内容

- **test/helpers/route-test-app.js（新規）**: ルートテスト共通の薄いハーネス（logger スタブ / ベース app / fake session / global.fetch 差し替え）。DB・msgbot スタブは各テストに残し、早すぎる抽象を回避
- **test/api-routes.test.js**: 土台部分をハーネス利用に変更（アサーション無変更のリファクタ、2挿入6削除）
- **test/webhook-routes.test.js（新規・7ブロック**）: /msg-webhook の join+group 成功・groupName 63文字切詰・非join/非group・events空・getGroupSummary例外→500・createLogCorrelationId無しロガー分岐
- **test/page-routes.test.js（新規・21ケース）**: OAuth 全分岐。fetch スタブは未知 URL で throw する厳格設計、失敗系は fetch 呼び出し回数で失敗地点をピン留め（検証削除で必ず落ちる非 vacuous 設計）
- **scripts/run-tests.js（新規）+ package.json**: test スクリプトの 15 ファイル `&&` 連鎖を glob ベースのランナーに置き換え（fail-fast・昇順逐次・NODE_V8_COVERAGE 子プロセス伝播維持）

## テスト

- `pnpm test`: 全17ファイルグリーン
- `pnpm run coverage`: 上表のとおり。他ファイルの数値低下なし
- プロダクトコード（routes/ lib/ app/）の変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)