### PR TITLE
fix: EUC-JP宣言メールのcharsetエイリアスにEUC-JISX0213を追加

### DIFF
--- a/lib/mail-text.js
+++ b/lib/mail-text.js
@@ -7,6 +7,10 @@ const decodeUtf8Buffer = (valueBuffer) => valueBuffer.toString('utf8');
 // 実体はWindows拡張(CP932 / ISO-2022-JP-MS)だが、メールがJIS標準の名前で
 // 宣言してくることが多いため、標準名を拡張対応版へ読み替える。
 // (標準規格の内容は拡張版でも完全に後方互換で復号できることを確認済み)
+// 注意: EUC-JPにはCP932系(EUC-JP-MS)とは別系統のJIS X0213拡張(EUC-JISX0213)
+// があり、この実行環境ではEUC-JP-MSが利用不可なためEUC-JISX0213のみ対応する。
+// そのため「髙」(はしご高、CP932/ISO-2022-JP-MS側の拡張文字)はEUC-JP経路では
+// 依然として消失する既知の限界(EUC-JISX0213には含まれない文字のため)。
 const CHARSET_ALIASES = {
   'shift_jis': 'CP932',
   'sjis': 'CP932',
@@ -14,6 +18,7 @@ const CHARSET_ALIASES = {
   'ms_kanji': 'CP932',
   'iso-2022-jp': 'ISO-2022-JP-MS',
   'csiso2022jp': 'ISO-2022-JP-MS',
+  'euc-jp': 'EUC-JISX0213',
 };
 
 const normalizeCharset = (charset) => CHARSET_ALIASES[charset.toLowerCase()] || charset;

--- a/test/mail-text.test.js
+++ b/test/mail-text.test.js
@@ -47,9 +47,26 @@ const run = () => {
 
   {
     // エイリアステーブルに無い charset はそのまま渡り、正常に動作する。
+    const encoder = new Iconv('UTF-8', 'ISO-8859-1//TRANSLIT//IGNORE');
+    const latin1 = encoder.convert(Buffer.from('hello world', 'utf8'));
+    assert.strictEqual(convertUtf8(latin1, 'ISO-8859-1'), 'hello world');
+  }
+
+  {
+    // 「㈱」(U+3231)はJIS X0208にはなくEUC-JISX0213拡張のみに存在する。
+    // charset="EUC-JP"と宣言されつつ実体がEUC-JISX0213拡張文字を含む
+    // ケースでも正しく復号できることを確認する。
+    const encoder = new Iconv('UTF-8', 'EUC-JISX0213//TRANSLIT//IGNORE');
+    const eucjp = encoder.convert(Buffer.from('㈱山田商店', 'utf8'));
+    assert.strictEqual(convertUtf8(eucjp, 'EUC-JP'), '㈱山田商店');
+  }
+
+  {
+    // 「龍」は標準JIS X0208範囲の通常の漢字であり、EUC-JPエイリアス化の
+    // 前後で挙動が変わらないことを確認する回帰テスト。
     const encoder = new Iconv('UTF-8', 'EUC-JP//TRANSLIT//IGNORE');
-    const eucjp = encoder.convert(Buffer.from('日本語テスト', 'utf8'));
-    assert.strictEqual(convertUtf8(eucjp, 'EUC-JP'), '日本語テスト');
+    const eucjp = encoder.convert(Buffer.from('龍', 'utf8'));
+    assert.strictEqual(convertUtf8(eucjp, 'EUC-JP'), '龍');
   }
 
   {
@@ -62,6 +79,10 @@ const run = () => {
     const jisMsEncoder = new Iconv('UTF-8', 'ISO-2022-JP-MS//TRANSLIT//IGNORE');
     const jisMs = jisMsEncoder.convert(Buffer.from('髙橋様', 'utf8'));
     assert.strictEqual(convertUtf8(jisMs, 'ISO-2022-JP-MS'), '髙橋様');
+
+    const jisx0213Encoder = new Iconv('UTF-8', 'EUC-JISX0213//TRANSLIT//IGNORE');
+    const jisx0213 = jisx0213Encoder.convert(Buffer.from('㈱山田商店', 'utf8'));
+    assert.strictEqual(convertUtf8(jisx0213, 'EUC-JISX0213'), '㈱山田商店');
   }
 
   {


### PR DESCRIPTION
## Summary
- PR #94(Shift_JIS/ISO-2022-JPのエイリアス対応)の続き。`charset="EUC-JP"` と宣言されつつ実体がJIS X0213拡張(`㈱`等)を含む場合、拡張文字が消失していた
- EUC-JPの拡張系統には別系統の `EUC-JP-MS`(CP932/IBM拡張系)と `EUC-JISX0213`(JIS X 0213:2004系)があり、単純な1対1エイリアスが安全か検証が必要だった
- 本番と同じAlpine/muslコンテナ(`mail-to-linemsg:test-alpine`)で実機検証: **`EUC-JP-MS` はこの実行環境では一切サポートされておらず**、選択肢は事実上 `EUC-JISX0213` のみ
- `EUC-JISX0213` は標準EUC-JP本文と完全に後方互換で、`①`・`㈱`・`﨑` は修復できる
- ただし **`髙`(はしご高)はEUC-JISX0213にも含まれないため、EUC-JP経路では既知の限界として引き続き復元不可**(コード内コメントで明記。`EUC-JP-MS`が使えない以上この実行環境では対応不可能)
- `EUC-JP` の実際の受信実績は未確認(Shift_JIS/ISO-2022-JPほどの実運用裏付けはない)が、将来の安全網として追加

## Test plan
- [x] `node test/mail-text.test.js` — 新規ケース+既存ケース全てpass
- [x] `node scripts/run-tests.js` — フルスイートpass、既存テストへの回帰なし
- [x] 本番同等のAlpine/muslコンテナで新規テストがpassすることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)