### PR TITLE
fix: メール本文切り詰めがIVS/ZWJ絵文字シーケンスを分断する問題を修正

### DIFF
--- a/lib/mail-text.js
+++ b/lib/mail-text.js
@@ -32,17 +32,61 @@ const convertUtf8 = (valueBuffer, charset) => {
   return cnv.convert(valueBuffer).toString('utf8');
 };
 
+// 切り詰めフロー:
+//
+//   message (コードポイント配列 messageChars, 長さ = charsBefore)
+//     │
+//     ├─ charsBefore <= maxChars ─────────────────► { text: message, truncated: false, ... }
+//     │
+//     └─ charsBefore > maxChars
+//           │
+//           ▼
+//     書記素クラスタを先頭から走査、truncatedLength(コードポイント基準)を
+//     超える直前の完全な書記素境界で停止 ─► safeLength
+//           │
+//           ▼
+//     messageChars.slice(0, safeLength) + marker ─► { text, truncated: true, ... }
+//
+// safeLength は必ず「完全な書記素クラスタの境界」であり、IVS/ZWJ絵文字
+// シーケンスの途中では止まらない。
 const truncateLineTextMessage = (message, options = {}) => {
   const maxChars = options.maxChars || 5000;
-  const marker = options.marker || '\r\n（省略）';
+  const marker = options.marker ?? '\r\n（省略）';
   const messageChars = Array.from(message);
-  if (messageChars.length <= maxChars) {
-    return message;
+  const charsBefore = messageChars.length;
+  if (charsBefore <= maxChars) {
+    return {
+      text: message,
+      truncated: false,
+      charsBefore,
+      charsAfter: charsBefore,
+    };
   }
 
   const markerChars = Array.from(marker);
   const truncatedLength = Math.max(maxChars - markerChars.length, 0);
-  return `${messageChars.slice(0, truncatedLength).join('')}${marker}`;
+
+  // コードポイント単位でtruncatedLength件に切るが、書記素クラスタ(IVS・ZWJ絵文字
+  // シーケンス等)の途中で切らないよう、直前の安全な境界まで戻す。maxChars自体は
+  // LINE APIの文字数上限(コードポイント基準)を守るため、書記素数には切り替えない。
+  let codePointCount = 0;
+  let safeLength = 0;
+  for (const { segment } of new Intl.Segmenter(undefined, { granularity: 'grapheme' }).segment(message)) {
+    const segmentCodePointLength = Array.from(segment).length;
+    if (codePointCount + segmentCodePointLength > truncatedLength) {
+      break;
+    }
+    codePointCount += segmentCodePointLength;
+    safeLength = codePointCount;
+  }
+
+  const text = `${messageChars.slice(0, safeLength).join('')}${marker}`;
+  return {
+    text,
+    truncated: true,
+    charsBefore,
+    charsAfter: Array.from(text).length,
+  };
 };
 
 module.exports = {

--- a/lib/mail-webhook.js
+++ b/lib/mail-webhook.js
@@ -331,17 +331,20 @@ const createMailWebhookHandler = ({
       mailContent.body = htmlToText.convert(htmlBody);
     }
     const lineMessageText = `From: ${mailContent.from}\r\nSubject: ${mailContent.subject}\r\n\r\n${mailContent.body}`;
-    const charsBefore = Array.from(lineMessageText).length;
-    const msgBody = truncateLineTextMessage(lineMessageText, {
+    const {
+      text: msgBody,
+      truncated,
+      charsBefore,
+      charsAfter,
+    } = truncateLineTextMessage(lineMessageText, {
       maxChars: lineTextMessageMaxChars,
       marker: lineTextMessageTruncationMarker,
     });
-    const charsAfter = Array.from(msgBody).length;
     logger.logInfo('mail_webhook.message.prepared', {
       requestId: req.requestId,
       charsBefore,
       charsAfter,
-      truncated: charsAfter < charsBefore,
+      truncated,
     });
     const channels = [
       {

--- a/test/mail-text.test.js
+++ b/test/mail-text.test.js
@@ -87,19 +87,84 @@ const run = () => {
 
   {
     const short = 'abc';
-    assert.strictEqual(truncateLineTextMessage(short, { maxChars: 5, marker: '...' }), 'abc');
+    assert.strictEqual(truncateLineTextMessage(short, { maxChars: 5, marker: '...' }).text, 'abc');
   }
 
   {
     const text = 'abcdef';
     const truncated = truncateLineTextMessage(text, { maxChars: 5, marker: '..' });
-    assert.strictEqual(truncated, 'abc..');
+    assert.strictEqual(truncated.text, 'abc..');
   }
 
   {
     const text = 'A😀BC😀D';
     const truncated = truncateLineTextMessage(text, { maxChars: 5, marker: '..' });
-    assert.strictEqual(truncated, 'A😀B..');
+    assert.strictEqual(truncated.text, 'A😀B..');
+  }
+
+  {
+    // IVS(異体字選択子)境界分断防止の確認。
+    // 「辻」+ IVS(U+E0100)は2コードポイントから成る1書記素クラスタ。
+    // maxChars=5, marker='..'(2コードポイント)なので truncatedLength=3。
+    // 先頭2文字'AB'(2コードポイント)の直後にこのIVSペアを置くと、
+    // 境界(3コードポイント目)がちょうどペアの内部(base側)にまたがる。
+    // この場合、ペア全体が除外され、baseだけ・selectorだけが残ることはない。
+    const base = '辻';
+    const ivs = '\u{E0100}';
+    const text = `AB${base}${ivs}CD`;
+    const result = truncateLineTextMessage(text, { maxChars: 5, marker: '..' });
+    assert.strictEqual(result.text, 'AB..');
+    assert.strictEqual(result.text.includes(base), false);
+    assert.strictEqual(result.text.includes(ivs), false);
+    assert.strictEqual(result.truncated, true);
+    assert.strictEqual(result.charsBefore, 6);
+    assert.strictEqual(result.charsAfter, 4);
+  }
+
+  {
+    // ZWJ絵文字境界分断防止の確認。
+    // 家族ZWJ絵文字「👨‍👩‍👧」(man, ZWJ, woman, ZWJ, girl)は5コードポイントから
+    // 成る1書記素クラスタ。maxChars=5, marker='..'なので truncatedLength=3。
+    // 先頭2文字'AB'の直後にこのZWJシーケンスを置くと、境界(3コードポイント目)が
+    // ちょうどシーケンスの内部にまたがる。この場合シーケンス全体が除外され、
+    // 一部の構成絵文字やZWJだけが孤立して残ることはない。
+    const family = '\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}';
+    const text = `AB${family}C`;
+    const result = truncateLineTextMessage(text, { maxChars: 5, marker: '..' });
+    assert.strictEqual(result.text, 'AB..');
+    assert.strictEqual(result.text.includes('\u{200D}'), false);
+    assert.strictEqual(result.truncated, true);
+    assert.strictEqual(result.charsBefore, 8);
+    assert.strictEqual(result.charsAfter, 4);
+  }
+
+  {
+    // marker: '' を明示指定した場合の回帰確認(`??`修正で既定値に差し戻らない)。
+    const text = 'abcdef';
+    const result = truncateLineTextMessage(text, { maxChars: 5, marker: '' });
+    assert.strictEqual(result.text, 'abcde');
+    assert.strictEqual(result.truncated, true);
+    assert.strictEqual(result.charsBefore, 6);
+    assert.strictEqual(result.charsAfter, 5);
+  }
+
+  {
+    // 戻り値の形状確認(切り詰めなし・切り詰めありの両方)。
+    const notTruncated = truncateLineTextMessage('abc', { maxChars: 5, marker: '..' });
+    assert.deepStrictEqual(notTruncated, {
+      text: 'abc',
+      truncated: false,
+      charsBefore: 3,
+      charsAfter: 3,
+    });
+
+    const truncated = truncateLineTextMessage('abcdef', { maxChars: 5, marker: '..' });
+    assert.deepStrictEqual(truncated, {
+      text: 'abc..',
+      truncated: true,
+      charsBefore: 6,
+      charsAfter: 5,
+    });
   }
 
   console.log('mail-text tests passed');

--- a/test/mail-webhook-delivery.test.js
+++ b/test/mail-webhook-delivery.test.js
@@ -264,6 +264,95 @@ const run = async () => {
     assert.strictEqual(failedLog.deadlineMs, 150);
   }
 
+  // 9. 本文中のIVS(異体字選択子)がLINEメッセージのmaxChars(5000)境界にまたがる
+  //    場合でも、書記素クラスタを分断せずに切り詰められる。
+  {
+    const logger = createCaptureLogger();
+    let pushedText;
+    const { app } = createWebhookTestApp({
+      logger,
+      pushMessage: async ({ messages }) => {
+        pushedText = messages[0].text;
+        return {};
+      },
+      mqttPublish: null,
+    });
+
+    const from = 'a@b.co';
+    const subject = 's';
+    // lib/mail-webhook.js の lineMessageText 組み立てと同じ形の接頭辞。
+    const prefix = `From: ${from}\r\nSubject: ${subject}\r\n\r\n`;
+    const prefixLen = Array.from(prefix).length;
+    const maxChars = 5000;
+    const marker = '\r\n（省略）';
+    const markerLen = Array.from(marker).length;
+    const truncatedLength = maxChars - markerLen;
+    const base = '辻';
+    const ivs = '\u{E0100}';
+    // 接頭辞+filler(単純ASCII)の直後にIVSペアを置き、境界(truncatedLength文字目)
+    // がちょうどペアの内部(base側)にまたがるように文字数を調整する。
+    const fillerBeforeLength = truncatedLength - 1 - prefixLen;
+    const filler = 'A'.repeat(fillerBeforeLength);
+    const suffix = 'Z'.repeat(50);
+    const body = `${filler}${base}${ivs}${suffix}`;
+
+    const res = await postMailWebhook(app, { from, subject, text: body });
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(pushedText.includes(base), false);
+    assert.strictEqual(pushedText.includes(ivs), false);
+    assert.ok(pushedText.endsWith(marker));
+
+    const preparedLog = logger.entries.find((entry) => entry.event === 'mail_webhook.message.prepared');
+    assert.strictEqual(preparedLog.truncated, true);
+    assert.strictEqual(preparedLog.charsBefore, prefixLen + fillerBeforeLength + 2 + suffix.length);
+    assert.strictEqual(preparedLog.charsAfter, fillerBeforeLength + prefixLen + markerLen);
+  }
+
+  // 10. 本文中の家族ZWJ絵文字がLINEメッセージのmaxChars(5000)境界にまたがる
+  //     場合でも、シーケンス全体を分断せずに切り詰められる。
+  {
+    const logger = createCaptureLogger();
+    let pushedText;
+    const { app } = createWebhookTestApp({
+      logger,
+      pushMessage: async ({ messages }) => {
+        pushedText = messages[0].text;
+        return {};
+      },
+      mqttPublish: null,
+    });
+
+    const from = 'a@b.co';
+    const subject = 's';
+    const prefix = `From: ${from}\r\nSubject: ${subject}\r\n\r\n`;
+    const prefixLen = Array.from(prefix).length;
+    const maxChars = 5000;
+    const marker = '\r\n（省略）';
+    const markerLen = Array.from(marker).length;
+    const truncatedLength = maxChars - markerLen;
+    const family = '\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}';
+    const familyCodePointLength = Array.from(family).length;
+    // 接頭辞+filler(単純ASCII)の直後に家族ZWJ絵文字を置き、境界(truncatedLength
+    // 文字目)がちょうどシーケンスの内部にまたがるように文字数を調整する。
+    const fillerBeforeLength = truncatedLength - 1 - prefixLen;
+    const filler = 'A'.repeat(fillerBeforeLength);
+    const suffix = 'Z'.repeat(50);
+    const body = `${filler}${family}${suffix}`;
+
+    const res = await postMailWebhook(app, { from, subject, text: body });
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(pushedText.includes('\u{200D}'), false);
+    assert.strictEqual(pushedText.includes('\u{1F468}'), false);
+    assert.ok(pushedText.endsWith(marker));
+
+    const preparedLog = logger.entries.find((entry) => entry.event === 'mail_webhook.message.prepared');
+    assert.strictEqual(preparedLog.truncated, true);
+    assert.strictEqual(preparedLog.charsBefore, prefixLen + fillerBeforeLength + familyCodePointLength + suffix.length);
+    assert.strictEqual(preparedLog.charsAfter, fillerBeforeLength + prefixLen + markerLen);
+  }
+
   console.log('mail webhook delivery tests passed');
 };
 


### PR DESCRIPTION
## Summary
- `truncateLineTextMessage`(`lib/mail-text.js`)がコードポイント単位でスライスしていたため、異体字シーケンス(IVS、例: 「龍」の異体字)やZWJ絵文字シーケンス(家族絵文字`👨‍👩‍👧‍👦`等)が`maxChars`境界とちょうど重なると、構成要素の一部だけが残る分断が起きていた
- **設計方針(`/plan-eng-review` + Outside Voice=Codexレビュー済み)**: 当初「書記素クラスタ数へ全面切替」を検討したが、`maxChars=5000`はLINE Messaging APIの実際の文字数上限(コードポイント/UTF-16基準)を守るガード(`docs/api-reference.md:106`)であり、書記素クラスタ数に置き換えるとLINE API上限保証が壊れるリスクがあると判明(CRLFが1書記素クラスタになる等を実測確認)。そのため**`maxChars`の判定はコードポイント基準のまま維持し、切り詰め位置だけを直前の安全な書記素クラスタ境界へ調整**する設計に変更した
- あわせて発見した既存バグ・改善も対応:
  - `marker: ''`(空文字)を指定しても`||`の優先評価で既定値に差し戻る既存バグを`??`に修正
  - `truncateLineTextMessage`の戻り値を文字列から`{ text, truncated, charsBefore, charsAfter }`オブジェクトに変更し、呼び出し側(`lib/mail-webhook.js`)の不正確になり得た`truncated: charsAfter < charsBefore`判定を解消

## Test plan
- [x] `node test/mail-text.test.js` — IVS/ZWJ境界分断防止・marker空文字回帰・戻り値形状の新規4ケース+既存3ケース全てpass(境界計算を手計算でも検証済み)
- [x] `node test/mail-webhook-delivery.test.js` — 実際にwebhook経由でIVS/ZWJが5000文字境界にまたがる本文を送信する統合テスト2件を追加、pass
- [x] `node scripts/run-tests.js` — フルスイートpass(exit code 0)、既存テストへの回帰なし
- [x] 本番同等のAlpine/muslコンテナで`Intl.Segmenter`が正しく動作することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)