### PR TITLE
fix: brace-expansion を1.1.16に更新しDoS脆弱性を修正 (GHSA-3jxr-9vmj-r5cp)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   brace-expansion: 2.0.3
   flatted: 3.4.2
   filelist>minimatch: 5.1.8
-  minimatch@3.1.4>brace-expansion: 1.1.13
+  minimatch@3.1.4>brace-expansion: 1.1.16
   minimatch: 3.1.4
   table>ajv: 8.18.0
   form-data: 4.0.6
@@ -438,8 +438,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
   broker-factory@3.1.15:
     resolution: {integrity: sha512-ko+aWvgNuP49meGrdjUu7rC+Y+Wai3cCPxP3xWwHsHfehFjOh5ZQM2yC4gEB2UddeZ/YXhm0K1eG/L6fxym2Og==}
@@ -2372,7 +2372,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -3434,7 +3434,7 @@ snapshots:
 
   minimatch@3.1.4:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.16
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ overrides:
   "brace-expansion": "2.0.3"
   "flatted": "3.4.2"
   "filelist>minimatch": "5.1.8"
-  "minimatch@3.1.4>brace-expansion": "1.1.13"
+  "minimatch@3.1.4>brace-expansion": "1.1.16"
   # minimatch は 3.1.4 に固定。これに合わせ c8 は ^9 系に固定している(c8@10+ は minimatch@9 を要求するため)
   "minimatch": "3.1.4"
   "table>ajv": "8.18.0"


### PR DESCRIPTION
## Summary
- Dependabot alertで指摘されたbrace-expansionのDoS脆弱性 (GHSA-3jxr-9vmj-r5cp, `<1.1.16`が脆弱) を修正
- `pnpm-workspace.yaml` の `minimatch@3.1.4>brace-expansion` scoped override を `1.1.13` → `1.1.16` に更新
- `minimatch@3.1.4` は `brace-expansion` の1.x系 (`^1.1.7`) にしか依存できないため、一般override(`2.0.3`)への統合はせず、既存方針(P19-1, 0e554b8)を踏襲してscoped overrideのバージョンのみ更新
- `npm audit fix` は本リポジトリがpnpm管理(package-lock.json不在)のため使用不可。pnpmのoverride更新で対応
- brace-expansion 1.1.13→1.1.16のソース差分を確認済み。公開API (`expandTop(str)`) は完全後方互換で、修正内容は再帰をループ化した内部実装のみ

## Test plan
- [x] `pnpm ls brace-expansion` で全パスが `1.1.16` に統一されていることを確認
- [x] `pnpm audit` で対象advisory (GHSA-3jxr-9vmj-r5cp) が解消されていることを確認
- [x] `pnpm run coverage` (CIと同じコマンド) が全テスト成功

## Note
`pnpm audit` には別件の未修正advisory (CVE-2026-14257, 入力長に応じたOOM, `<=5.0.7`) が残っていますが、1.x系にまだ修正版がリリースされておらず対応不可。現時点でGitHub dependabot alertにはなっていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)