### PR TITLE
Restrict Fly deploy workflow triggers

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -4,6 +4,20 @@ on:
   push:
     branches:
       - master
+    paths:
+      - index.js
+      - db-pgsql.js
+      - mqtt-publish.js
+      - app/**
+      - lib/**
+      - routes/**
+      - pages/**
+      - public/**
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - Dockerfile
+      - .github/deploy-fly/fly.template.toml
   workflow_dispatch:
 
 permissions:

--- a/docs/deploy-fly.md
+++ b/docs/deploy-fly.md
@@ -77,7 +77,7 @@ GitHub Actions では対話ログインを行いません。
 1. Secrets を登録する
 2. Variables を登録する
 3. `.github/workflows/deploy-fly.yml` を `master` へマージする
-4. `master` への push か `workflow_dispatch` でデプロイを実行する
+4. アプリ本体かデプロイ設定の変更を含む `master` への push、または `workflow_dispatch` でデプロイを実行する
 5. Actions ログで deploy 成功を確認する
 
 ## 検証項目


### PR DESCRIPTION
## 概要

- Fly.ioデプロイの自動起動条件をアプリ本体とデプロイ設定の変更に限定
- docs更新やCI workflowのみの変更では自動デプロイしないよう整理
- deploy-fly手順書の説明を実際の起動条件に合わせて更新

## 確認

- .github/workflows/deploy-fly.yml と docs/deploy-fly.md の変更を確認
- git diff --check を実行して問題なし
